### PR TITLE
feat: update theme to match Figma design system

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "ScrapeGraphAI",
   "colors": {
-    "primary": "#9333ea",
-    "light": "#9f52eb",
-    "dark": "#1f2937"
+    "primary": "#AC6DFF",
+    "light": "#AC6DFF",
+    "dark": "#AC6DFF"
   },
   "favicon": "/favicon.svg",
   "navigation": {
@@ -279,7 +279,18 @@
   },
   "background": {
     "color": {
-      "dark": "#101725"
+      "dark": "#242424",
+      "light": "#EFEFEF"
+    }
+  },
+  "fonts": {
+    "heading": {
+      "family": "IBM Plex Sans",
+      "weight": 500
+    },
+    "body": {
+      "family": "IBM Plex Sans",
+      "weight": 400
     }
   },
   "navbar": {


### PR DESCRIPTION
## Summary
- Updated primary/light/dark colors from purple shades to **Strong Lilac** (`#AC6DFF`) matching the Figma design system
- Changed dark background from `#101725` to **Black C64** (`#242424`) and added light background **White OS** (`#EFEFEF`)
- Added **IBM Plex Sans** font configuration for headings (Medium/500) and body (Regular/400)

## Test plan
- [ ] Verify the docs site renders correctly in both light and dark mode
- [ ] Confirm IBM Plex Sans loads properly for headings and body text
- [ ] Check that links, buttons, and interactive elements use the new Strong Lilac color
- [ ] Validate background colors match the Figma design system specs


Made with [Cursor](https://cursor.com)