### PR TITLE
Fix logo 403 by using relative paths (#37)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -273,8 +273,8 @@
     }
   },
   "logo": {
-    "light": "https://raw.githubusercontent.com/ScrapeGraphAI/docs-mintlify/main/logo/light.svg",
-    "dark": "https://raw.githubusercontent.com/ScrapeGraphAI/docs-mintlify/main/logo/dark.svg",
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg",
     "href": "https://docs.scrapegraphai.com"
   },
   "background": {


### PR DESCRIPTION
## Summary
- Logo assets were loaded from `raw.githubusercontent.com`, which GitHub rate-limits/blocks with 403 when hotlinked from another origin.
- Point `docs.json` to the local `/logo/light.svg` and `/logo/dark.svg` so Mintlify serves them directly.

Fixes #37

## Test plan
- [ ] Verify the navbar logo renders on https://docs.scrapegraphai.com after deploy (both light and dark themes)
- [ ] Confirm no `403` on `/logo/*.svg` in browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)