### PR TITLE
docs(v2): refresh snippets to match scrapegraph-py 2.x and scrapegrap…

### DIFF
--- a/sdks/javascript.mdx
+++ b/sdks/javascript.mdx
@@ -20,23 +20,23 @@ icon: "js"
 </CardGroup>
 
 <Note>
-`scrapegraph-js@2` is **ESM-only** and requires **Node ≥ 22**.
+These docs cover **`scrapegraph-js` ≥ 2.0.1**. The v2 SDK is **ESM-only** and requires **Node ≥ 22**. Earlier `0.x`/`1.x` releases expose a different, deprecated API.
 </Note>
 
 ## Installation
 
 ```bash
 # npm
-npm i scrapegraph-js
+npm i scrapegraph-js@latest     # pins a version >= 2.0.1
 
 # pnpm
-pnpm add scrapegraph-js
+pnpm add scrapegraph-js@latest
 
 # yarn
-yarn add scrapegraph-js
+yarn add scrapegraph-js@latest
 
 # bun
-bun add scrapegraph-js
+bun add scrapegraph-js@latest
 ```
 
 ## What's new in v2

--- a/sdks/javascript.mdx
+++ b/sdks/javascript.mdx
@@ -12,55 +12,72 @@ icon: "js"
 
 <CardGroup cols={2}>
   <Card title="NPM Package" icon="box">
-    [![npm
-    version](https://badge.fury.io/js/scrapegraph-js.svg)](https://badge.fury.io/js/scrapegraph-js)
+    [![npm version](https://badge.fury.io/js/scrapegraph-js.svg)](https://badge.fury.io/js/scrapegraph-js)
   </Card>
   <Card title="License" icon="scale">
     [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
   </Card>
 </CardGroup>
 
+<Note>
+`scrapegraph-js@2` is **ESM-only** and requires **Node ≥ 22**.
+</Note>
+
 ## Installation
 
 ```bash
-# Using npm
+# npm
 npm i scrapegraph-js
 
-# Using pnpm
-pnpm i scrapegraph-js
+# pnpm
+pnpm add scrapegraph-js
 
-# Using yarn
+# yarn
 yarn add scrapegraph-js
 
-# Using bun
+# bun
 bun add scrapegraph-js
 ```
+
+## What's new in v2
+
+- **New entry point**: `import { ScrapeGraphAI } from "scrapegraph-js"` and instantiate once — no more passing the API key to every call.
+- **Nested resources**: `sgai.crawl.*`, `sgai.monitor.*`, `sgai.history.*`.
+- **`ApiResult<T>` wrapper**: no throws — every call returns `{ status, data, error, elapsedMs }`.
+- **Auto-picks the API key** from `SGAI_API_KEY` (or pass `{ apiKey }` to the factory).
+- **Removed**: `markdownify`, `agenticScraper`, `sitemap`, `feedback` — use `sgai.scrape()` with the right format entry instead.
+
+<Warning>
+v2 is a breaking change. See the [Migration Guide](/transition-from-v1-to-v2) if you're upgrading from v1.
+</Warning>
 
 ## Quick Start
 
 ```javascript
-import { scrape } from "scrapegraph-js";
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await scrape("your-api-key", {
+// reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI({ apiKey: "..." })
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.scrape({
   url: "https://example.com",
   formats: [{ type: "markdown" }],
 });
 
-if (result.status === "success") {
-  console.log(result.data?.results.markdown?.data);
+if (res.status === "success") {
+  console.log(res.data?.results.markdown?.data?.[0]);
 } else {
-  console.error(result.error);
+  console.error(res.error);
 }
 ```
 
 <Note>
-Store your API keys securely in environment variables. Use `.env` files and
-libraries like `dotenv` to load them into your app.
+Store your API keys securely in environment variables. Use `.env` files and libraries like `dotenv` to load them into your app.
 </Note>
 
 ## Return Type
 
-All functions return `ApiResult<T>`:
+Every method returns `ApiResult<T>`:
 
 ```typescript
 type ApiResult<T> = {
@@ -71,26 +88,24 @@ type ApiResult<T> = {
 };
 ```
 
-Check `result.status` before accessing `result.data`.
+Check `res.status` before accessing `res.data`.
 
 ## Services
 
-### scrape
+### `sgai.scrape()`
 
-Scrape a webpage in multiple formats (markdown, html, screenshot, json, etc).
+Fetch a page in one or more formats (markdown, html, screenshot, json, links, images, summary, branding).
 
 ```javascript
-import { scrape } from "scrapegraph-js";
-
-const result = await scrape("your-api-key", {
+const res = await sgai.scrape({
   url: "https://example.com",
   formats: [
     { type: "markdown", mode: "reader" },
     { type: "screenshot", fullPage: true, width: 1440, height: 900 },
     { type: "json", prompt: "Extract product info" },
   ],
-  contentType: "text/html",        // optional, auto-detected
-  fetchConfig: {                   // optional
+  contentType: "text/html",      // optional, auto-detected
+  fetchConfig: {                 // optional
     mode: "js",
     stealth: true,
     timeout: 30000,
@@ -102,28 +117,26 @@ const result = await scrape("your-api-key", {
 
 #### Parameters
 
-| Parameter            | Type          | Required | Description                                              |
-| -------------------- | ------------- | -------- | -------------------------------------------------------- |
-| url                  | string        | Yes      | The URL of the webpage to scrape                         |
-| formats              | FormatEntry[] | No       | Array of format entries. Defaults to `[{ type: "markdown" }]` |
-| contentType          | string        | No       | Override the detected content type (e.g. `"application/pdf"`) |
-| fetchConfig          | FetchConfig   | No       | Fetch configuration                                      |
+| Parameter     | Type            | Required | Description                                                   |
+| ------------- | --------------- | -------- | ------------------------------------------------------------- |
+| `url`         | `string`        | Yes      | URL to scrape                                                 |
+| `formats`     | `FormatEntry[]` | No       | Defaults to `[{ type: "markdown" }]`                          |
+| `contentType` | `string`        | No       | Override detected content type (e.g. `"application/pdf"`)     |
+| `fetchConfig` | `FetchConfig`   | No       | Fetch configuration                                           |
 
 **Formats:**
-- `markdown` -- Clean markdown (modes: `normal`, `reader`, `prune`)
-- `html` -- Raw HTML (modes: `normal`, `reader`, `prune`)
-- `links` -- All links on the page
-- `images` -- All image URLs
-- `summary` -- AI-generated summary
-- `json` -- Structured extraction with prompt/schema
-- `branding` -- Brand colors, typography, logos
-- `screenshot` -- Page screenshot (fullPage, width, height, quality)
+- `markdown` — Clean markdown (modes: `normal`, `reader`, `prune`)
+- `html` — Raw HTML (modes: `normal`, `reader`, `prune`)
+- `links` — All links on the page
+- `images` — All image URLs
+- `summary` — AI-generated summary
+- `json` — Structured extraction with prompt/schema
+- `branding` — Brand colors, typography, logos
+- `screenshot` — Page screenshot (`fullPage`, `width`, `height`, `quality`)
 
-<Accordion title="Multi-format Example" icon="code">
+<Accordion title="Multi-format example" icon="code">
 ```javascript
-import { scrape } from "scrapegraph-js";
-
-const result = await scrape("your-api-key", {
+const res = await sgai.scrape({
   url: "https://example.com",
   formats: [
     { type: "markdown", mode: "reader" },
@@ -133,54 +146,51 @@ const result = await scrape("your-api-key", {
   ],
 });
 
-if (result.status === "success") {
-  const results = result.data?.results;
-  console.log("Markdown:", results?.markdown?.data);
-  console.log("Links:", results?.links?.data);
-  console.log("Screenshot URL:", results?.screenshot?.data.url);
+if (res.status === "success") {
+  const r = res.data?.results;
+  console.log("Markdown:", r?.markdown?.data?.[0]?.slice(0, 200));
+  console.log("Links:", r?.links?.metadata?.count);
+  console.log("Screenshot URL:", r?.screenshot?.data.url);
 }
 ```
 </Accordion>
 
-### extract
+### `sgai.extract()`
 
-Extract structured data from a URL, HTML, or markdown using AI.
+Extract structured data from a URL, HTML, or markdown.
 
 ```javascript
-import { extract } from "scrapegraph-js";
-
-const result = await extract("your-api-key", {
+const res = await sgai.extract({
   url: "https://example.com",
   prompt: "Extract the main heading and description",
 });
 
-if (result.status === "success") {
-  console.log(result.data?.json);
+if (res.status === "success") {
+  console.log(res.data?.json);
+  console.log("Tokens:", res.data?.usage);
 }
 ```
 
 #### Parameters
 
-| Parameter            | Type        | Required | Description                                              |
-| -------------------- | ----------- | -------- | -------------------------------------------------------- |
-| url                  | string      | Yes\*    | The URL of the webpage to scrape                         |
-| prompt               | string      | Yes      | A description of what you want to extract                |
-| schema               | object      | No       | JSON schema for structured response                      |
-| mode                 | string      | No       | HTML processing mode: `"normal"`, `"reader"`, `"prune"`  |
-| contentType          | string      | No       | Override the detected content type                       |
-| html                 | string      | No       | Raw HTML input (alternative to `url`)                    |
-| markdown             | string      | No       | Raw markdown input (alternative to `url`)                |
-| fetchConfig          | FetchConfig | No       | Fetch configuration                                      |
+| Parameter     | Type          | Required | Description                                              |
+| ------------- | ------------- | -------- | -------------------------------------------------------- |
+| `url`         | `string`      | Yes\*    | URL of the page                                          |
+| `html`        | `string`      | Yes\*    | Raw HTML (alternative to `url`)                          |
+| `markdown`    | `string`      | Yes\*    | Raw markdown (alternative to `url`)                      |
+| `prompt`      | `string`      | Yes      | What to extract                                          |
+| `schema`      | `object`      | No       | JSON schema for structured output                        |
+| `mode`        | `string`      | No       | HTML processing mode: `"normal"`, `"reader"`, `"prune"`  |
+| `contentType` | `string`      | No       | Override the detected content type                       |
+| `fetchConfig` | `FetchConfig` | No       | Fetch configuration                                      |
 
 <Note>
 \*One of `url`, `html`, or `markdown` is required.
 </Note>
 
-<Accordion title="With JSON Schema" icon="code">
+<Accordion title="With a JSON schema" icon="code">
 ```javascript
-import { extract } from "scrapegraph-js";
-
-const result = await extract("your-api-key", {
+const res = await sgai.extract({
   url: "https://example.com/article",
   prompt: "Extract the article information",
   schema: {
@@ -195,27 +205,24 @@ const result = await extract("your-api-key", {
   },
 });
 
-if (result.status === "success") {
-  console.log("Extracted:", result.data?.json);
-  console.log("Tokens:", result.data?.usage);
+if (res.status === "success") {
+  console.log(res.data?.json);
 }
 ```
 </Accordion>
 
-### search
+### `sgai.search()`
 
-Search the web and optionally extract structured data.
+Web search with optional AI extraction.
 
 ```javascript
-import { search } from "scrapegraph-js";
-
-const result = await search("your-api-key", {
+const res = await sgai.search({
   query: "best programming languages 2024",
   numResults: 5,
 });
 
-if (result.status === "success") {
-  for (const r of result.data?.results ?? []) {
+if (res.status === "success") {
+  for (const r of res.data?.results ?? []) {
     console.log(`${r.title} - ${r.url}`);
   }
 }
@@ -223,23 +230,20 @@ if (result.status === "success") {
 
 #### Parameters
 
-| Parameter                | Type        | Required | Description                                              |
-| ------------------------ | ----------- | -------- | -------------------------------------------------------- |
-| query                    | string      | Yes      | The search query (1-500 chars)                           |
-| numResults               | number      | No       | Number of results (1-20). Default: 3                     |
-| prompt                   | string      | No       | Prompt for AI extraction from results                    |
-| schema                   | object      | No       | JSON schema for structured response (requires `prompt`)  |
-| format                   | string      | No       | `"markdown"` (default) or `"html"`                       |
-| mode                     | string      | No       | HTML processing mode: `"normal"`, `"reader"`, `"prune"` (default) |
-| locationGeoCode          | string      | No       | Country code for localized search (e.g. `"us"`)          |
-| timeRange                | string      | No       | Recency filter: `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"` |
-| fetchConfig              | FetchConfig | No       | Fetch configuration                                      |
+| Parameter         | Type          | Required | Description                                                         |
+| ----------------- | ------------- | -------- | ------------------------------------------------------------------- |
+| `query`           | `string`      | Yes      | Search query (1–500 chars)                                          |
+| `numResults`      | `number`      | No       | Number of results (1–20). Default: `3`                              |
+| `prompt`          | `string`      | No       | Prompt for AI extraction from the fetched results                   |
+| `schema`          | `object`      | No       | JSON schema (requires `prompt`)                                     |
+| `format`          | `string`      | No       | `"markdown"` (default) or `"html"`                                  |
+| `timeRange`       | `string`      | No       | `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"` |
+| `locationGeoCode` | `string`      | No       | Two-letter country code (e.g. `"us"`)                               |
+| `fetchConfig`     | `FetchConfig` | No       | Fetch configuration                                                 |
 
-<Accordion title="Search with Extraction" icon="code">
+<Accordion title="Search + extraction" icon="code">
 ```javascript
-import { search } from "scrapegraph-js";
-
-const result = await search("your-api-key", {
+const res = await sgai.search({
   query: "typescript best practices",
   numResults: 5,
   prompt: "Extract the main tips and recommendations",
@@ -251,40 +255,19 @@ const result = await search("your-api-key", {
   },
 });
 
-if (result.status === "success") {
-  console.log("Results:", result.data?.results.length);
-  console.log("Extracted:", result.data?.json);
+if (res.status === "success") {
+  console.log("Results:", res.data?.results.length);
+  console.log("Extracted:", res.data?.json);
 }
 ```
 </Accordion>
 
-### generateSchema
+### `sgai.crawl.*`
 
-Generate a JSON schema from a natural language description.
-
-```javascript
-import { generateSchema } from "scrapegraph-js";
-
-const result = await generateSchema("your-api-key", {
-  prompt: "Schema for a product with name, price, and rating",
-  existingSchema: { /* optional, to modify */ },
-});
-
-if (result.status === "success") {
-  console.log("Refined prompt:", result.data?.refinedPrompt);
-  console.log("Schema:", result.data?.schema);
-}
-```
-
-### crawl
-
-Crawl a website and its linked pages.
+Crawl a site. Access the resource via `sgai.crawl`.
 
 ```javascript
-import { crawl } from "scrapegraph-js";
-
-// Start a crawl
-const result = await crawl.start("your-api-key", {
+const start = await sgai.crawl.start({
   url: "https://example.com",
   formats: [{ type: "markdown" }],
   maxPages: 50,
@@ -292,71 +275,65 @@ const result = await crawl.start("your-api-key", {
   maxLinksPerPage: 10,
   includePatterns: ["/blog/*"],
   excludePatterns: ["/admin/*"],
-  fetchConfig: { /* ... */ },
 });
 
-console.log("Crawl ID:", result.data?.id);
+const crawlId = start.data?.id;
 
-// Check status
-const status = await crawl.get("your-api-key", result.data?.id);
+// Status
+await sgai.crawl.get(crawlId);
 
-// Control crawl
-await crawl.stop("your-api-key", result.data?.id);
-await crawl.resume("your-api-key", result.data?.id);
-await crawl.delete("your-api-key", result.data?.id);
+// Control
+await sgai.crawl.stop(crawlId);
+await sgai.crawl.resume(crawlId);
+await sgai.crawl.delete(crawlId);
 ```
 
-#### crawl.start() Parameters
+#### `crawl.start()` parameters
 
-| Parameter                   | Type          | Required | Description                                              |
-| --------------------------- | ------------- | -------- | -------------------------------------------------------- |
-| url                         | string        | Yes      | The starting URL                                         |
-| formats                     | FormatEntry[] | No       | Output formats per page. Defaults to `[{ type: "markdown" }]` |
-| maxDepth                    | number        | No       | Maximum crawl depth. Default: `2`                        |
-| maxPages                    | number        | No       | Maximum pages to crawl (1-1000). Default: `50`           |
-| maxLinksPerPage              | number        | No       | Maximum links followed per page. Default: `10`           |
-| allowExternal               | boolean       | No       | Allow crossing domains. Default: `false`                 |
-| includePatterns              | string[]      | No       | URL patterns to include                                  |
-| excludePatterns              | string[]      | No       | URL patterns to exclude                                  |
-| contentTypes                 | string[]      | No       | Allowed content types                                    |
-| fetchConfig                  | FetchConfig   | No       | Fetch configuration                                      |
+| Parameter          | Type            | Required | Description                                              |
+| ------------------ | --------------- | -------- | -------------------------------------------------------- |
+| `url`              | `string`        | Yes      | Starting URL                                             |
+| `formats`          | `FormatEntry[]` | No       | Defaults to `[{ type: "markdown" }]`                     |
+| `maxDepth`         | `number`        | No       | Maximum crawl depth. Default: `2`                        |
+| `maxPages`         | `number`        | No       | Maximum pages (1–1000). Default: `50`                    |
+| `maxLinksPerPage`  | `number`        | No       | Links followed per page. Default: `10`                   |
+| `allowExternal`    | `boolean`       | No       | Allow crossing domains. Default: `false`                 |
+| `includePatterns`  | `string[]`      | No       | URL patterns to include                                  |
+| `excludePatterns`  | `string[]`      | No       | URL patterns to exclude                                  |
+| `contentTypes`     | `string[]`      | No       | Allowed content types                                    |
+| `fetchConfig`      | `FetchConfig`   | No       | Fetch configuration                                      |
 
-### monitor
+### `sgai.monitor.*`
 
-Monitor a webpage for changes on a schedule.
+Scheduled monitoring jobs.
 
 ```javascript
-import { monitor } from "scrapegraph-js";
-
-// Create a monitor
-const result = await monitor.create("your-api-key", {
+// Create
+const res = await sgai.monitor.create({
   url: "https://example.com",
   name: "Price Monitor",
-  interval: "0 * * * *",           // cron expression
+  interval: "0 * * * *",       // cron expression
   formats: [{ type: "markdown" }],
-  webhookUrl: "https://...",       // optional
-  fetchConfig: { /* ... */ },
+  webhookUrl: "https://...",   // optional
 });
 
-console.log("Monitor ID:", result.data?.cronId);
+const cronId = res.data?.cronId;
 
-// Manage monitors
-const all = await monitor.list("your-api-key");
-const details = await monitor.get("your-api-key", cronId);
-await monitor.update("your-api-key", cronId, { interval: "0 */6 * * *" });
-await monitor.pause("your-api-key", cronId);
-await monitor.resume("your-api-key", cronId);
-await monitor.delete("your-api-key", cronId);
+// Manage
+await sgai.monitor.list();
+await sgai.monitor.get(cronId);
+await sgai.monitor.update(cronId, { interval: "0 */6 * * *" });
+await sgai.monitor.pause(cronId);
+await sgai.monitor.resume(cronId);
+await sgai.monitor.delete(cronId);
 ```
 
-#### monitor.activity() — poll tick history
+#### `monitor.activity()` — poll tick history
 
-Paginate through per-run ticks for a monitor (what changed on each scheduled run).
+Paginate through per-run ticks.
 
 ```javascript
-import { monitor } from "scrapegraph-js";
-
-const activity = await monitor.activity("your-api-key", cronId, { limit: 20 });
+const activity = await sgai.monitor.activity(cronId, { limit: 20 });
 
 if (activity.status === "success") {
   for (const tick of activity.data?.ticks ?? []) {
@@ -365,7 +342,7 @@ if (activity.status === "success") {
   }
 
   if (activity.data?.nextCursor) {
-    const next = await monitor.activity("your-api-key", cronId, {
+    const next = await sgai.monitor.activity(cronId, {
       limit: 20,
       cursor: activity.data.nextCursor,
     });
@@ -373,88 +350,62 @@ if (activity.status === "success") {
 }
 ```
 
-Params: `limit` (1–100, default `20`), `cursor` (opaque pagination token). Each tick has `id`, `createdAt`, `status`, `changed`, `elapsedMs`, and `diffs` with per-format deltas.
+Params: `limit` (1–100, default `20`) and `cursor` for pagination. Each tick exposes `id`, `createdAt`, `status`, `changed`, `elapsedMs`, and `diffs`.
 
-### getCredits
-
-Check your account credit balance.
+### `sgai.history.*`
 
 ```javascript
-import { getCredits } from "scrapegraph-js";
-
-const result = await getCredits("your-api-key");
-
-if (result.status === "success") {
-  console.log(`Remaining: ${result.data?.remaining}`);
-  console.log(`Used: ${result.data?.used}`);
-  console.log(`Plan: ${result.data?.plan}`);
-}
-```
-
-### checkHealth
-
-Check API health status.
-
-```javascript
-import { checkHealth } from "scrapegraph-js";
-
-const result = await checkHealth("your-api-key");
-// { status: "ok", uptime: 12345 }
-```
-
-### history
-
-Fetch request history.
-
-```javascript
-import { history } from "scrapegraph-js";
-
-const list = await history.list("your-api-key", {
-  service: "scrape",               // optional filter
+const list = await sgai.history.list({
+  service: "scrape",   // optional filter
   page: 1,
   limit: 20,
 });
 
-const entry = await history.get("your-api-key", "request-id");
+const entry = await sgai.history.get("request-id");
+```
+
+### `sgai.credits()` / `sgai.healthy()`
+
+```javascript
+const credits = await sgai.credits();
+// { remaining: 1000, used: 500, plan: "pro", jobs: { crawl: {...}, monitor: {...} } }
+
+const health = await sgai.healthy();
+// { status: "ok", uptime: 12345 }
 ```
 
 ## Configuration Objects
 
 ### FetchConfig
 
-Controls how pages are fetched. See the [proxy configuration guide](/services/additional-parameters/proxy) for details on modes and geotargeting.
+Controls how pages are fetched. See the [proxy configuration guide](/services/additional-parameters/proxy) for details.
 
 ```javascript
 {
-  mode: 'js',                  // Fetch mode: auto, fast, js
-  stealth: true,               // Enable stealth mode (residential proxy, anti-bot headers)
-  timeout: 15000,              // Request timeout in ms (1000-60000)
-  wait: 2000,                  // Wait after page load in ms (0-30000)
-  scrolls: 3,                  // Number of scrolls (0-100)
-  country: 'us',               // Proxy country code (ISO 3166-1 alpha-2)
-  headers: { 'X-Custom': 'header' },
-  cookies: { key: 'value' },
-  mock: false,                 // Enable mock mode for testing
+  mode: "js",          // "auto" (default) | "fast" | "js"
+  stealth: true,        // Residential proxies / anti-bot headers
+  timeout: 15000,       // ms (1000–60000)
+  wait: 2000,           // ms after page load (0–30000)
+  scrolls: 3,           // 0–100
+  country: "us",        // ISO 3166-1 alpha-2
+  headers: { "X-Custom": "header" },
+  cookies: { key: "value" },
+  mock: false,          // Enable mock mode for testing
 }
 ```
 
-
 ## Error Handling
 
-Functions return `ApiResult<T>` with a `status` field. Check `status` before accessing `data`:
-
 ```javascript
-import { extract } from "scrapegraph-js";
-
-const result = await extract("your-api-key", {
+const res = await sgai.extract({
   url: "https://example.com",
   prompt: "Extract the title",
 });
 
-if (result.status === "success") {
-  console.log(result.data);
+if (res.status === "success") {
+  console.log(res.data);
 } else {
-  console.error(`Request failed: ${result.error}`);
+  console.error(`Request failed: ${res.error}`);
 }
 ```
 
@@ -462,7 +413,8 @@ if (result.status === "success") {
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SGAI_API_URL` | Override API base URL | `https://api.scrapegraphai.com/api/v2` |
+| `SGAI_API_KEY` | Your ScrapeGraphAI API key | — |
+| `SGAI_API_URL` | Override API base URL | `https://v2-api.scrapegraphai.com/api` |
 | `SGAI_DEBUG` | Enable debug logging (`"1"`) | off |
 | `SGAI_TIMEOUT` | Request timeout in seconds | `120` |
 

--- a/sdks/python.mdx
+++ b/sdks/python.mdx
@@ -74,7 +74,7 @@ class ApiResult(BaseModel, Generic[T]):
 | Variable        | Description                                  | Default                                 |
 | --------------- | -------------------------------------------- | --------------------------------------- |
 | `SGAI_API_KEY`  | Your ScrapeGraphAI API key                   | —                                       |
-| `SGAI_API_URL`  | Override API base URL                        | `https://api.scrapegraphai.com/api/v2`  |
+| `SGAI_API_URL`  | Override API base URL                        | `https://v2-api.scrapegraphai.com/api`  |
 | `SGAI_TIMEOUT`  | Request timeout in seconds                   | `120`                                   |
 | `SGAI_DEBUG`    | Enable debug logging (set to `"1"`)          | off                                     |
 

--- a/services/crawl.mdx
+++ b/services/crawl.mdx
@@ -231,7 +231,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain)

--- a/services/crawl.mdx
+++ b/services/crawl.mdx
@@ -6,10 +6,10 @@ icon: 'spider'
 
 ## Overview
 
-Crawl is an advanced web crawling service that traverses multiple pages, follows links, and returns content in your preferred format (markdown or HTML). It provides namespaced operations for starting, monitoring, stopping, and resuming crawl jobs.
+Crawl traverses a site starting from a URL, follows links up to a depth you set, and returns each page in the formats you request. Crawls are async — you start a job, then poll (or get notified via webhook) until it completes.
 
 <Note>
-Try Crawl instantly in our [interactive playground](https://scrapegraphai.com/dashboard) 
+Try Crawl instantly in our [interactive playground](https://scrapegraphai.com/dashboard).
 </Note>
 
 ## Getting Started
@@ -19,53 +19,83 @@ Try Crawl instantly in our [interactive playground](https://scrapegraphai.com/da
 <CodeGroup>
 
 ```python Python
-from scrapegraph_py import Client
+import time
+from scrapegraph_py import ScrapeGraphAI, CrawlRequest, MarkdownFormatConfig
 
-client = Client(api_key="your-api-key")
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
 
-# Start a crawl
-response = client.crawl.start(
-    "https://example.com",
-    depth=2,
-    max_pages=10,
-    format="markdown",
-)
-print("Crawl started:", response)
+start = sgai.crawl.start(CrawlRequest(
+    url="https://scrapegraphai.com/",
+    formats=[MarkdownFormatConfig()],
+    max_pages=5,
+    max_depth=2,
+))
+
+if start.status != "success":
+    print("Failed:", start.error)
+else:
+    crawl_id = start.data.id
+    print("Crawl started:", crawl_id)
+
+    while True:
+        time.sleep(2)
+        status = sgai.crawl.get(crawl_id)
+        if status.status != "success":
+            break
+        print(f"{status.data.finished}/{status.data.total} - {status.data.status}")
+        if status.data.status in ("completed", "failed"):
+            for page in status.data.pages:
+                print(f"  {page.url} - {page.status}")
+            break
 ```
 
 ```javascript JavaScript
-import { crawl } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const job = await crawl.start('your-api-key', {
-  url: 'https://example.com',
+const sgai = ScrapeGraphAI();
+
+const start = await sgai.crawl.start({
+  url: "https://scrapegraphai.com/",
+  formats: [{ type: "markdown" }],
+  maxPages: 5,
   maxDepth: 2,
-  maxPages: 10,
-  formats: [{ type: 'markdown' }],
 });
 
-if (job.status === 'success') {
-  console.log('Crawl started:', job.data?.id);
+if (start.status !== "success" || !start.data) {
+  console.error("Failed:", start.error);
+} else {
+  const crawlId = start.data.id;
+  console.log("Crawl started:", crawlId);
 
-  // Check status
-  const status = await crawl.get('your-api-key', job.data?.id);
-
-  // Stop / Resume / Delete
-  await crawl.stop('your-api-key', job.data?.id);
-  await crawl.resume('your-api-key', job.data?.id);
-  await crawl.delete('your-api-key', job.data?.id);
+  while (true) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const status = await sgai.crawl.get(crawlId);
+    if (status.status !== "success" || !status.data) break;
+    console.log(`${status.data.finished}/${status.data.total} - ${status.data.status}`);
+    if (status.data.status === "completed" || status.data.status === "failed") {
+      for (const p of status.data.pages) console.log(`  ${p.url} - ${p.status}`);
+      break;
+    }
+  }
 }
 ```
 
 ```bash cURL
-curl -X POST https://api.scrapegraphai.com/api/v2/crawl \
+# Start a crawl
+curl -X POST https://v2-api.scrapegraphai.com/api/crawl \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-api-key" \
   -d '{
-    "url": "https://example.com",
-    "depth": 2,
-    "max_pages": 10,
-    "format": "markdown"
+    "url": "https://scrapegraphai.com/",
+    "formats": [{ "type": "markdown" }],
+    "maxPages": 5,
+    "maxDepth": 2
   }'
+
+# Check status (replace :id with the crawl id returned above)
+curl -X GET https://v2-api.scrapegraphai.com/api/crawl/:id \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
 ```
 
 </CodeGroup>
@@ -74,80 +104,108 @@ curl -X POST https://api.scrapegraphai.com/api/v2/crawl \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| url | string | Yes | The starting URL to crawl. |
-| depth | int | No | How many levels deep to follow links. |
-| max_pages | int | No | Maximum number of pages to crawl. |
-| format | string | No | Output format: `"markdown"` or `"html"`. Default: `"markdown"`. |
-| include_patterns | list | No | URL patterns to include (e.g., `["/blog/*"]`). |
-| exclude_patterns | list | No | URL patterns to exclude (e.g., `["/admin/*"]`). |
-| fetch_config | FetchConfig | No | Configuration for page fetching (headers, stealth, etc.). |
+| `url` | string | Yes | Starting URL to crawl. |
+| `formats` | array | No | Output formats per page (see [Scrape formats](/services/scrape#output-formats)). |
+| `maxPages` / `max_pages` | int | No | Maximum number of pages to crawl. |
+| `maxDepth` / `max_depth` | int | No | How many levels deep to follow links. |
+| `maxLinksPerPage` / `max_links_per_page` | int | No | Cap on links expanded per page. |
+| `includePatterns` / `include_patterns` | array | No | URL patterns to include (e.g. `["/blog/*"]`). |
+| `excludePatterns` / `exclude_patterns` | array | No | URL patterns to exclude (e.g. `["/admin/*"]`). |
+| `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>
-Get your API key from the [dashboard](https://scrapegraphai.com/dashboard)
+Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
 </Note>
+
+<Accordion title="Example Response (start)" icon="terminal">
+```json
+{
+  "id": "79694e03-f2ea-43f2-93cc-7c6fc26f999a",
+  "status": "running",
+  "total": 3,
+  "finished": 0,
+  "pages": []
+}
+```
+</Accordion>
+
+<Accordion title="Example Response (get)" icon="terminal">
+```json
+{
+  "id": "79694e03-f2ea-43f2-93cc-7c6fc26f999a",
+  "status": "completed",
+  "total": 3,
+  "finished": 1,
+  "pages": [
+    {
+      "url": "https://example.com",
+      "depth": 0,
+      "title": "",
+      "status": "completed",
+      "parentUrl": null,
+      "contentType": "text/html",
+      "links": ["https://iana.org/domains/example"],
+      "scrapeRefId": "83a911ed-c0bc-4a8c-ad62-8efeeb93f33a"
+    }
+  ]
+}
+```
+</Accordion>
 
 ## Managing Crawl Jobs
 
-### Check Status
-
 ```python
-status = client.crawl.status(crawl_id)
-print("Status:", status)
+# Check status
+status = sgai.crawl.get(crawl_id)
+
+# Stop / resume / delete
+sgai.crawl.stop(crawl_id)
+sgai.crawl.resume(crawl_id)
+sgai.crawl.delete(crawl_id)
 ```
 
-### Stop a Running Crawl
-
-```python
-client.crawl.stop(crawl_id)
-```
-
-### Resume a Stopped Crawl
-
-```python
-client.crawl.resume(crawl_id)
+```javascript
+await sgai.crawl.get(crawlId);
+await sgai.crawl.stop(crawlId);
+await sgai.crawl.resume(crawlId);
+await sgai.crawl.delete(crawlId);
 ```
 
 ## Advanced Usage
 
-### With FetchConfig
+### URL patterns and fetch config
 
 ```python
-from scrapegraph_py import Client, FetchConfig
+from scrapegraph_py import ScrapeGraphAI, CrawlRequest, MarkdownFormatConfig, FetchConfig
 
-client = Client(api_key="your-api-key")
+sgai = ScrapeGraphAI()
 
-response = client.crawl.start(
-    "https://example.com",
-    depth=2,
+res = sgai.crawl.start(CrawlRequest(
+    url="https://example.com",
+    formats=[MarkdownFormatConfig()],
+    max_depth=2,
     max_pages=10,
-    format="markdown",
     include_patterns=["/blog/*"],
     exclude_patterns=["/admin/*"],
-    fetch_config=FetchConfig(
-        mode="js",
-        stealth=True,
-        wait=1000,
-        headers={"User-Agent": "MyBot"},
-    ),
-)
+    fetch_config=FetchConfig(mode="js", stealth=True, wait=1000),
+))
 ```
 
-### Async Support
+### Async Support (Python)
 
 ```python
 import asyncio
-from scrapegraph_py import AsyncClient
+from scrapegraph_py import AsyncScrapeGraphAI, CrawlRequest
 
 async def main():
-    async with AsyncClient(api_key="your-api-key") as client:
-        job = await client.crawl.start(
-            "https://example.com",
-            depth=2,
+    async with AsyncScrapeGraphAI() as sgai:
+        start = await sgai.crawl.start(CrawlRequest(
+            url="https://example.com",
             max_pages=5,
-        )
-        
-        status = await client.crawl.status(job["id"])
-        print("Crawl status:", status)
+            max_depth=2,
+        ))
+        status = await sgai.crawl.get(start.data.id)
+        print("Status:", status.data.status)
 
 asyncio.run(main())
 ```
@@ -156,34 +214,34 @@ asyncio.run(main())
 
 <CardGroup cols={2}>
   <Card title="Multi-Page Crawling" icon="sitemap">
-    Traverse entire websites following links automatically
+    Traverse entire sites, following links automatically.
   </Card>
   <Card title="Flexible Formats" icon="file-lines">
-    Get results in markdown or HTML format
+    Request markdown, HTML, links, images, and more per page.
   </Card>
   <Card title="Job Control" icon="sliders">
-    Start, stop, resume, and monitor crawl jobs
+    Start, stop, resume, and delete crawl jobs.
   </Card>
   <Card title="URL Filtering" icon="filter">
-    Include or exclude pages by URL patterns
+    Include or exclude by URL pattern.
   </Card>
 </CardGroup>
 
 ## Integration Options
 
 ### Official SDKs
-- [Python SDK](/sdks/python) - Perfect for data science and backend applications
-- [JavaScript SDK](/sdks/javascript) - Ideal for web applications and Node.js
+- [Python SDK](/sdks/python)
+- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
 
 ### AI Framework Integrations
-- [LangChain Integration](/integrations/langchain) - Use Crawl in your LLM workflows
-- [LlamaIndex Integration](/integrations/llamaindex) - Build powerful search and QA systems
+- [LangChain Integration](/integrations/langchain)
+- [LlamaIndex Integration](/integrations/llamaindex)
 
 ## Support & Resources
 
 <CardGroup cols={2}>
   <Card title="Documentation" icon="book" href="/introduction">
-    Comprehensive guides and tutorials
+    Guides and tutorials
   </Card>
   <Card title="API Reference" icon="code" href="/api-reference/introduction">
     Detailed API documentation

--- a/services/extract.mdx
+++ b/services/extract.mdx
@@ -6,10 +6,10 @@ icon: 'robot'
 
 ## Overview
 
-Extract is our flagship LLM-powered web scraping service that intelligently extracts structured data from any website. Using advanced LLM models, it understands context and content like a human would, making web data extraction more reliable and efficient than ever.
+Extract uses an LLM to pull structured data from a URL, HTML, or markdown. Provide a prompt (and optionally a JSON schema) and it returns typed JSON — no selectors or post-processing required.
 
 <Note>
-Try Extract instantly in our [interactive playground](https://scrapegraphai.com/dashboard) 
+Try Extract instantly in our [interactive playground](https://scrapegraphai.com/dashboard).
 </Note>
 
 ## Getting Started
@@ -19,36 +19,47 @@ Try Extract instantly in our [interactive playground](https://scrapegraphai.com/
 <CodeGroup>
 
 ```python Python
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, ExtractRequest
 
-client = Client(api_key="your-api-key")
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
 
-response = client.extract(
-    url="https://scrapegraphai.com/",
-    prompt="Extract info about the company"
-)
+res = sgai.extract(ExtractRequest(
+    url="https://scrapegraphai.com",
+    prompt="What does the company do? Extract name and description.",
+))
+
+if res.status == "success":
+    print(res.data.json_data)
+else:
+    print("Failed:", res.error)
 ```
 
 ```javascript JavaScript
-import { extract } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await extract('your-api-key', {
-  url: 'https://scrapegraphai.com',
-  prompt: 'What does the company do?',
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.extract({
+  url: "https://scrapegraphai.com",
+  prompt: "What does the company do? Extract name and description.",
 });
 
-if (result.status === 'success') {
-  console.log(result.data?.json);
+if (res.status === "success") {
+  console.log(res.data?.json);
+  console.log("Tokens used:", res.data?.usage);
+} else {
+  console.error(res.error);
 }
 ```
 
 ```bash cURL
-curl -X POST https://api.scrapegraphai.com/api/v2/extract \
+curl -X POST https://v2-api.scrapegraphai.com/api/extract \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-api-key" \
   -d '{
-    "url": "https://example.com",
-    "prompt": "Extract product details including name, price, and availability."
+    "url": "https://scrapegraphai.com",
+    "prompt": "What does the company do? Extract name and description."
   }'
 ```
 
@@ -58,191 +69,192 @@ curl -X POST https://api.scrapegraphai.com/api/v2/extract \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| url | string | Yes | The URL of the webpage to scrape. |
-| prompt | string | Yes | A textual description of what you want to extract. |
-| output_schema | object | No | Pydantic or Zod schema for structured response format. |
-| fetch_config | FetchConfig | No | Configuration for page fetching (headers, cookies, stealth, etc.). |
+| `url` | string | Cond. | URL of the page to extract from. One of `url`, `html`, or `markdown` is required. |
+| `html` | string | Cond. | Raw HTML to extract from. |
+| `markdown` | string | Cond. | Markdown content to extract from. |
+| `prompt` | string | Yes | Natural-language description of what to extract. |
+| `schema` | object | No | JSON schema describing the desired output shape. |
+| `mode` | string | No | HTML processing mode: `"normal"`, `"reader"`, `"prune"`. |
+| `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>
-Get your API key from the [dashboard](https://scrapegraphai.com/dashboard)
+Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
 </Note>
 
 <Accordion title="Example Response" icon="terminal">
 ```json
 {
-  "id": "sg-req-abc123",
-  "status": "completed",
-  "result": {
-    "company_name": "ScrapeGraphAI",
-    "description": "ScrapeGraphAI is a powerful AI scraping API designed for efficient web data extraction...",
-    "features": [
-      "Effortless, cost-effective, and AI-powered data extraction",
-      "Handles proxy rotation and rate limits",
-      "Supports a wide variety of websites"
-    ]
+  "id": "9a2178b6-2525-4f98-85e6-9f8c7da17541",
+  "raw": null,
+  "json": {
+    "name": "ScrapeGraphAI",
+    "description": "ScrapeGraphAI is an AI-powered web scraping platform that uses natural language prompts to turn any webpage into structured data via a simple API."
+  },
+  "usage": {
+    "promptTokens": 10002,
+    "completionTokens": 509
+  },
+  "metadata": {
+    "chunker": { "chunks": [{ "size": 5000 }, { "size": 2535 }] },
+    "fetch": {}
   }
 }
 ```
 </Accordion>
 
-## FetchConfig
+## With a JSON Schema
 
-Use `FetchConfig` to control how the page is fetched:
-
-```python
-from scrapegraph_py import Client, FetchConfig
-
-client = Client(api_key="your-api-key")
-
-response = client.extract(
-    url="https://example.com",
-    prompt="Extract the main content",
-    fetch_config=FetchConfig(
-        mode="js",
-        stealth=True,
-        headers={"User-Agent": "MyBot"},
-        cookies={"session": "abc123"},
-        scrolls=3,
-        wait=2000,
-    ),
-)
-```
-
-<Note>
-In the JavaScript SDK, pass `fetchConfig` as a property of the params object: `extract(apiKey, { url, prompt, fetchConfig: { ... } })`.
-</Note>
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| mode | string | Fetch mode: `"auto"` (default), `"fast"`, or `"js"`. |
-| stealth | bool | Enable stealth mode with residential proxy and anti-bot headers. |
-| headers | dict | Custom HTTP headers to send. |
-| cookies | dict | Cookies to include in the request. |
-| scrolls | int | Number of page scrolls (0-100). |
-| wait | int | Milliseconds to wait after page load (0-30000). |
-| timeout | int | Request timeout in milliseconds (1000-60000). |
-| country | string | Two-letter ISO country code for geo-targeted proxy routing. |
-
-## Custom Schema Example
-
-Define exactly what data you want to extract:
+Pass a JSON schema to pin down the exact output shape.
 
 <CodeGroup>
 
 ```python Python
-from pydantic import BaseModel, Field
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, ExtractRequest
 
-class ArticleData(BaseModel):
-    title: str = Field(description="Article title")
-    author: str = Field(description="Author name")
-    content: str = Field(description="Main article content")
-    publish_date: str = Field(description="Publication date")
+sgai = ScrapeGraphAI()
 
-client = Client(api_key="your-api-key")
+res = sgai.extract(ExtractRequest(
+    url="https://example.com",
+    prompt="Extract structured information about this page",
+    schema={
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "links": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["title"],
+    },
+))
 
-response = client.extract(
-    url="https://example.com/article",
-    prompt="Extract the article information",
-    output_schema=ArticleData
-)
+if res.status == "success":
+    print(res.data.json_data)
 ```
 
 ```javascript JavaScript
-import { extract } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await extract('your-api-key', {
-  url: 'https://scrapegraphai.com/',
-  prompt: 'What does the company do?',
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.extract({
+  url: "https://example.com",
+  prompt: "Extract the page title and description",
   schema: {
-    type: 'object',
+    type: "object",
     properties: {
-      title: { type: 'string' },
-      description: { type: 'string' },
-      summary: { type: 'string' },
+      title: { type: "string" },
+      description: { type: "string" },
     },
-    required: ['title'],
+    required: ["title"],
   },
 });
 
-if (result.status === 'success') {
-  console.log(result.data?.json);
+if (res.status === "success") {
+  console.log(res.data?.json);
 }
 ```
 
-</CodeGroup>
-
-## Async Support
-
-For applications requiring asynchronous execution:
-
-<CodeGroup>
-
-```python Python
-import asyncio
-from scrapegraph_py import AsyncClient
-
-async def main():
-    async with AsyncClient(api_key="your-api-key") as client:
-        urls = [
-            "https://scrapegraphai.com/",
-            "https://github.com/ScrapeGraphAI/Scrapegraph-ai",
-        ]
-
-        tasks = [
-            client.extract(
-                url=url,
-                prompt="Summarize the main content",
-            )
-            for url in urls
-        ]
-
-        responses = await asyncio.gather(*tasks, return_exceptions=True)
-
-        for i, response in enumerate(responses):
-            if isinstance(response, Exception):
-                print(f"Error for {urls[i]}: {response}")
-            else:
-                print(f"Result for {urls[i]}: {response}")
-
-if __name__ == "__main__":
-    asyncio.run(main())
+```bash cURL
+curl -X POST https://v2-api.scrapegraphai.com/api/extract \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "prompt": "Extract the page title and description",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "title": {"type": "string"},
+        "description": {"type": "string"}
+      },
+      "required": ["title"]
+    }
+  }'
 ```
 
 </CodeGroup>
+
+## Extract from HTML or Markdown
+
+Skip the fetch and extract from content you already have.
+
+```python
+from scrapegraph_py import ScrapeGraphAI, ExtractRequest
+
+sgai = ScrapeGraphAI()
+
+res = sgai.extract(ExtractRequest(
+    html="<html><body><h1>Widget</h1><p>$9.99</p></body></html>",
+    prompt="Extract product name and price",
+))
+```
+
+## FetchConfig
+
+Control how the page is fetched before extraction (JS rendering, stealth, headers, etc). See the full options in [Scrape · FetchConfig](/services/scrape#fetchconfig).
+
+```python
+from scrapegraph_py import ScrapeGraphAI, ExtractRequest, FetchConfig
+
+sgai = ScrapeGraphAI()
+
+res = sgai.extract(ExtractRequest(
+    url="https://example.com",
+    prompt="Extract the main content",
+    fetch_config=FetchConfig(mode="js", stealth=True, wait=2000),
+))
+```
+
+## Async Support (Python)
+
+```python
+import asyncio
+from scrapegraph_py import AsyncScrapeGraphAI, ExtractRequest
+
+async def main():
+    async with AsyncScrapeGraphAI() as sgai:
+        res = await sgai.extract(ExtractRequest(
+            url="https://scrapegraphai.com",
+            prompt="Summarize what this product does",
+        ))
+        if res.status == "success":
+            print(res.data.json_data)
+
+asyncio.run(main())
+```
 
 ## Key Features
 
 <CardGroup cols={2}>
   <Card title="Universal Compatibility" icon="globe">
-    Works with any website structure, including JavaScript-rendered content
+    Works with any URL, raw HTML, or markdown input.
   </Card>
   <Card title="AI Understanding" icon="brain">
-    Contextual understanding of content for accurate extraction
+    Contextual extraction — no XPath or brittle selectors.
   </Card>
   <Card title="Structured Output" icon="table">
-    Returns clean, structured data in your preferred format
+    JSON schema support for typed, predictable results.
   </Card>
-  <Card title="Schema Support" icon="code">
-    Define custom output schemas using Pydantic or Zod
+  <Card title="Token Accounting" icon="coins">
+    Response includes prompt/completion token usage.
   </Card>
 </CardGroup>
 
 ## Integration Options
 
 ### Official SDKs
-- [Python SDK](/sdks/python) - Perfect for data science and backend applications
-- [JavaScript SDK](/sdks/javascript) - Ideal for web applications and Node.js
+- [Python SDK](/sdks/python)
+- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
 
 ### AI Framework Integrations
-- [LangChain Integration](/integrations/langchain) - Use Extract in your LLM workflows
-- [LlamaIndex Integration](/integrations/llamaindex) - Build powerful search and QA systems
+- [LangChain Integration](/integrations/langchain)
+- [LlamaIndex Integration](/integrations/llamaindex)
 
 ## Support & Resources
 
 <CardGroup cols={2}>
   <Card title="Documentation" icon="book" href="/introduction">
-    Comprehensive guides and tutorials
+    Guides and tutorials
   </Card>
   <Card title="API Reference" icon="code" href="/api-reference/introduction">
     Detailed API documentation

--- a/services/extract.mdx
+++ b/services/extract.mdx
@@ -244,7 +244,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain)

--- a/services/monitor.mdx
+++ b/services/monitor.mdx
@@ -222,7 +222,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
 
 ## Support & Resources
 

--- a/services/monitor.mdx
+++ b/services/monitor.mdx
@@ -1,15 +1,15 @@
 ---
 title: 'Monitor'
-description: 'Scheduled web monitoring with AI-powered extraction'
+description: 'Scheduled web monitoring with AI-powered extraction and change detection'
 icon: 'clock'
 ---
 
 ## Overview
 
-Monitor enables you to set up recurring web scraping jobs that automatically extract data on a schedule. Create monitors that run on a cron schedule and extract structured data from any webpage.
+Monitor watches a page on a cron schedule, fetches it in the formats you specify (markdown, JSON, screenshot…), and records change diffs between runs. Optionally push each tick to a webhook.
 
 <Note>
-Try Monitor in our [dashboard](https://scrapegraphai.com/dashboard) 
+Try Monitor in our [dashboard](https://scrapegraphai.com/dashboard).
 </Note>
 
 ## Getting Started
@@ -19,51 +19,51 @@ Try Monitor in our [dashboard](https://scrapegraphai.com/dashboard)
 <CodeGroup>
 
 ```python Python
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, MonitorCreateRequest, MarkdownFormatConfig
 
-client = Client(api_key="your-api-key")
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
 
-# Create a monitor
-monitor = client.monitor.create(
-    name="Price Tracker",
-    url="https://example.com/products",
-    prompt="Extract current product prices",
-    interval="0 9 * * *",  # Daily at 9 AM
-)
-print("Monitor created:", monitor)
+res = sgai.monitor.create(MonitorCreateRequest(
+    url="https://example.com",
+    name="Homepage watch",
+    interval="*/30 * * * *",   # every 30 minutes
+    formats=[MarkdownFormatConfig()],
+))
+
+if res.status == "success":
+    print("Monitor id:", res.data.cron_id)
+else:
+    print("Failed:", res.error)
 ```
 
 ```javascript JavaScript
-import { monitor } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await monitor.create('your-api-key', {
-  name: 'Price Tracker',
-  url: 'https://example.com/products',
-  interval: '0 9 * * *',  // Daily at 9 AM
-  formats: [{ type: 'markdown' }],
-  webhookUrl: 'https://your-server.com/webhook',  // optional
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.monitor.create({
+  url: "https://example.com",
+  name: "Homepage watch",
+  interval: "*/30 * * * *",    // every 30 minutes
+  formats: [{ type: "markdown" }],
+  webhookUrl: "https://your-server.com/webhook", // optional
 });
 
-if (result.status === 'success') {
-  console.log('Monitor created:', result.data?.cronId);
-
-  // List / Get / Pause / Resume / Delete
-  const monitors = await monitor.list('your-api-key');
-  await monitor.pause('your-api-key', result.data?.cronId);
-  await monitor.resume('your-api-key', result.data?.cronId);
-  await monitor.delete('your-api-key', result.data?.cronId);
+if (res.status === "success") {
+  console.log("Monitor id:", res.data?.cronId);
 }
 ```
 
 ```bash cURL
-curl -X POST https://api.scrapegraphai.com/api/v2/monitor \
+curl -X POST https://v2-api.scrapegraphai.com/api/monitor \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-api-key" \
   -d '{
-    "name": "Price Tracker",
-    "url": "https://example.com/products",
-    "prompt": "Extract current product prices",
-    "interval": "0 9 * * *"
+    "url": "https://example.com",
+    "name": "Homepage watch",
+    "interval": "*/30 * * * *",
+    "formats": [{ "type": "markdown" }]
   }'
 ```
 
@@ -73,150 +73,162 @@ curl -X POST https://api.scrapegraphai.com/api/v2/monitor \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| name | string | Yes | A descriptive name for the monitor. |
-| url | string | Yes | The URL to monitor. |
-| prompt | string | Yes | What data to extract on each run. |
-| interval | string | Yes | Cron expression for the schedule (5 fields, e.g., `"0 9 * * *"` for daily at 9 AM). |
-| output_schema | object | No | JSON Schema (Python dict / JS object) for structured response format. |
-| fetch_config | FetchConfig | No | Configuration for page fetching (mode, stealth, headers, wait, etc.). |
+| `url` | string | Yes | The URL to monitor. |
+| `name` | string | Yes | Human-readable monitor name. |
+| `interval` | string | Yes | 5-field cron expression (e.g. `"*/10 * * * *"`). |
+| `formats` | array | No | Formats to capture each tick (see [Scrape formats](/services/scrape#output-formats)). |
+| `webhookUrl` / `webhook_url` | string | No | URL to receive tick payloads. |
+| `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>
-Get your API key from the [dashboard](https://scrapegraphai.com/dashboard)
+Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
 </Note>
+
+<Accordion title="Example Response (create)" icon="terminal">
+```json
+{
+  "cronId": "d9a09a07-5052-4262-a0b4-606cbd942287",
+  "scheduleId": "scd_8752XzxtXmLmrvgGzwLVG42iGKaz",
+  "interval": "*/30 * * * *",
+  "status": "active",
+  "config": {
+    "url": "https://example.com",
+    "name": "Homepage watch",
+    "formats": [{ "mode": "normal", "type": "markdown" }],
+    "interval": "*/30 * * * *",
+    "fetchConfig": { "mode": "auto", "wait": 0, "scrolls": 0, "stealth": false, "timeout": 30000 }
+  },
+  "createdAt": "2026-04-19T14:51:02.203Z",
+  "updatedAt": "2026-04-19T14:51:02.203Z"
+}
+```
+</Accordion>
 
 ## Managing Monitors
 
-### List All Monitors
+<CodeGroup>
 
-```python
-monitors = client.monitor.list()
-print("All monitors:", monitors)
+```python Python
+# List all
+sgai.monitor.list()
+
+# Inspect one
+sgai.monitor.get(monitor_id)
+
+# Change schedule or formats
+from scrapegraph_py import MonitorUpdateRequest
+sgai.monitor.update(monitor_id, MonitorUpdateRequest(interval="0 */6 * * *"))
+
+# Pause / resume / delete
+sgai.monitor.pause(monitor_id)
+sgai.monitor.resume(monitor_id)
+sgai.monitor.delete(monitor_id)
+
+# Recent ticks + diffs
+activity = sgai.monitor.activity(monitor_id)
+for tick in activity.data.ticks:
+    print(tick.created_at, "changed" if tick.changed else "no change")
 ```
 
-### Get a Specific Monitor
+```javascript JavaScript
+await sgai.monitor.list();
+await sgai.monitor.get(monitorId);
+await sgai.monitor.update(monitorId, { interval: "0 */6 * * *" });
+await sgai.monitor.pause(monitorId);
+await sgai.monitor.resume(monitorId);
+await sgai.monitor.delete(monitorId);
 
-```python
-monitor = client.monitor.get(monitor_id)
-print("Monitor details:", monitor)
-```
-
-### Pause a Monitor
-
-```python
-client.monitor.pause(monitor_id)
-```
-
-### Resume a Monitor
-
-```python
-client.monitor.resume(monitor_id)
-```
-
-### Delete a Monitor
-
-```python
-client.monitor.delete(monitor_id)
-```
-
-## Advanced Usage
-
-### With Output Schema and Config
-
-```python
-from scrapegraph_py import Client, FetchConfig
-
-schema = {
-    "type": "object",
-    "properties": {
-        "products": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "price": {"type": "number"},
-                    "in_stock": {"type": "boolean"},
-                },
-                "required": ["name", "price"],
-            },
-        },
-    },
+const activity = await sgai.monitor.activity(monitorId);
+for (const tick of activity.data?.ticks ?? []) {
+  console.log(tick.createdAt, tick.changed ? "CHANGED" : "no change");
 }
-
-client = Client(api_key="your-api-key")
-
-monitor = client.monitor.create(
-    name="Product Price Monitor",
-    url="https://example.com/products",
-    prompt="Extract product names, prices, and stock status",
-    interval="0 */6 * * *",  # Every 6 hours
-    output_schema=schema,
-    fetch_config=FetchConfig(mode="js", stealth=True, wait=2000),
-)
 ```
 
-### Async Support
+</CodeGroup>
+
+## Structured extraction on every tick
+
+Use the `json` format inside a monitor to extract the same typed payload on each run — then `activity` will include diffs between runs.
+
+```python
+from scrapegraph_py import ScrapeGraphAI, MonitorCreateRequest, JsonFormatConfig
+
+sgai = ScrapeGraphAI()
+
+res = sgai.monitor.create(MonitorCreateRequest(
+    url="https://time.is/",
+    name="Time Monitor",
+    interval="*/10 * * * *",
+    formats=[JsonFormatConfig(
+        prompt="Extract the current time",
+        schema={
+            "type": "object",
+            "properties": {"time": {"type": "string"}},
+            "required": ["time"],
+        },
+    )],
+))
+```
+
+## Async Support (Python)
 
 ```python
 import asyncio
-from scrapegraph_py import AsyncClient
+from scrapegraph_py import AsyncScrapeGraphAI, MonitorCreateRequest, MarkdownFormatConfig
 
 async def main():
-    async with AsyncClient(api_key="your-api-key") as client:
-        monitor = await client.monitor.create(
-            name="Tracker",
+    async with AsyncScrapeGraphAI() as sgai:
+        res = await sgai.monitor.create(MonitorCreateRequest(
             url="https://example.com",
-            prompt="Extract prices",
-            interval="0 9 * * *",
-        )
-
-        monitors = await client.monitor.list()
-        print("All monitors:", monitors)
+            name="async watch",
+            interval="0 * * * *",
+            formats=[MarkdownFormatConfig()],
+        ))
+        if res.status == "success":
+            print(res.data.cron_id)
 
 asyncio.run(main())
 ```
-
-## Key Features
-
-<CardGroup cols={2}>
-  <Card title="Scheduled Extraction" icon="calendar">
-    Run extraction jobs on any cron schedule
-  </Card>
-  <Card title="AI-Powered" icon="brain">
-    Use natural language prompts to define what to extract
-  </Card>
-  <Card title="Full Control" icon="sliders">
-    Create, pause, resume, and delete monitors easily
-  </Card>
-  <Card title="Schema Support" icon="code">
-    Define structured output with Pydantic or Zod schemas
-  </Card>
-</CardGroup>
 
 ## Common Cron Expressions
 
 | Expression | Schedule |
 |-----------|----------|
-| `0 9 * * *` | Daily at 9 AM |
+| `*/10 * * * *` | Every 10 minutes |
+| `*/30 * * * *` | Every 30 minutes |
 | `0 */6 * * *` | Every 6 hours |
+| `0 9 * * *` | Daily at 9 AM |
 | `0 9 * * 1` | Every Monday at 9 AM |
 | `0 0 1 * *` | First day of every month |
-| `*/30 * * * *` | Every 30 minutes |
+
+## Key Features
+
+<CardGroup cols={2}>
+  <Card title="Scheduled Extraction" icon="calendar">
+    Any cron schedule, down to per-minute granularity.
+  </Card>
+  <Card title="Change Detection" icon="diff">
+    Each tick records diffs vs. the previous run.
+  </Card>
+  <Card title="Webhooks" icon="bolt">
+    Push tick payloads to your own server via `webhookUrl`.
+  </Card>
+  <Card title="Structured Output" icon="code">
+    Combine with the `json` format for typed monitoring.
+  </Card>
+</CardGroup>
 
 ## Integration Options
 
 ### Official SDKs
-- [Python SDK](/sdks/python) - Perfect for data science and backend applications
-- [JavaScript SDK](/sdks/javascript) - Ideal for web applications and Node.js
-
-### AI Framework Integrations
-- [LangChain Integration](/integrations/langchain) - Use Monitor in your LLM workflows
+- [Python SDK](/sdks/python)
+- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
 
 ## Support & Resources
 
 <CardGroup cols={2}>
   <Card title="Documentation" icon="book" href="/introduction">
-    Comprehensive guides and tutorials
+    Guides and tutorials
   </Card>
   <Card title="API Reference" icon="code" href="/api-reference/introduction">
     Detailed API documentation

--- a/services/scrape.mdx
+++ b/services/scrape.mdx
@@ -340,7 +340,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python) — perfect for automation and data processing
-- [JavaScript SDK](/sdks/javascript) — ideal for web applications and Node.js (≥ 22)
+- [JavaScript SDK](/sdks/javascript) — ideal for web applications and Node.js (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain) — use Scrape in your content pipelines

--- a/services/scrape.mdx
+++ b/services/scrape.mdx
@@ -1,15 +1,15 @@
 ---
 title: 'Scrape'
-description: 'Scrape web pages in markdown, HTML, or screenshot format'
+description: 'Scrape web pages in markdown, HTML, screenshot, JSON, and more'
 icon: 'code'
 ---
 
 ## Overview
 
-The Scrape service fetches web page content and returns it in your preferred format: markdown, HTML, screenshot, or branding. It replaces the previous Markdownify service and supports flexible output through a simple `format` parameter.
+The Scrape service fetches a web page and returns content in one or more formats at the same time: markdown, HTML, links, images, summary, JSON extraction, branding, or screenshots. It replaces the previous Markdownify service and uses a flexible `formats` array so a single call can return any combination you need.
 
 <Note>
-Try the Scrape service instantly in our [interactive playground](https://scrapegraphai.com/dashboard) 
+Try the Scrape service instantly in our [interactive playground](https://scrapegraphai.com/dashboard).
 </Note>
 
 ## Getting Started
@@ -19,47 +19,47 @@ Try the Scrape service instantly in our [interactive playground](https://scrapeg
 <CodeGroup>
 
 ```python Python
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, ScrapeRequest, MarkdownFormatConfig
 
-client = Client(api_key="your-api-key")
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
 
-# Get markdown (default)
-response = client.scrape("https://example.com")
+res = sgai.scrape(ScrapeRequest(
+    url="https://example.com",
+    formats=[MarkdownFormatConfig()],
+))
 
-# Get HTML
-response = client.scrape("https://example.com", format="html")
-
-# Get screenshot
-response = client.scrape("https://example.com", format="screenshot")
+if res.status == "success":
+    print(res.data.results["markdown"]["data"][0])
+else:
+    print("Failed:", res.error)
 ```
 
 ```javascript JavaScript
-import { scrape } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-// Get markdown (default)
-const result = await scrape('your-api-key', {
-  url: 'https://example.com',
-  formats: [{ type: 'markdown' }],
+// reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI({ apiKey: "..." })
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.scrape({
+  url: "https://example.com",
+  formats: [{ type: "markdown" }],
 });
 
-// Get HTML
-const htmlResult = await scrape('your-api-key', {
-  url: 'https://example.com',
-  formats: [{ type: 'html' }],
-});
-
-if (result.status === 'success') {
-  console.log(result.data?.results.markdown?.data);
+if (res.status === "success") {
+  console.log(res.data?.results.markdown?.data?.[0]);
+} else {
+  console.error(res.error);
 }
 ```
 
 ```bash cURL
-curl -X POST https://api.scrapegraphai.com/api/v2/scrape \
+curl -X POST https://v2-api.scrapegraphai.com/api/scrape \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-api-key" \
   -d '{
     "url": "https://example.com",
-    "format": "markdown"
+    "formats": [{ "type": "markdown" }]
   }'
 ```
 
@@ -69,22 +69,26 @@ curl -X POST https://api.scrapegraphai.com/api/v2/scrape \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| url | string | Yes | The URL of the webpage to scrape. |
-| format | string | No | Output format: `"markdown"` (default), `"html"`, `"screenshot"`, or `"branding"`. |
-| fetch_config | FetchConfig | No | Configuration for page fetching (headers, stealth, etc.). |
+| `url` | string | Yes | The URL of the webpage to scrape. |
+| `formats` | array | Yes | One or more output formats (see [Formats](#output-formats)). |
+| `contentType` | string | No | Override auto-detected content type (e.g. `"text/html"`, `"application/pdf"`). |
+| `fetchConfig` / `fetch_config` | object | No | Fetch options — `mode`, `stealth`, `headers`, `cookies`, `scrolls`, `wait`, `timeout`, `country`. |
 
 <Note>
-Get your API key from the [dashboard](https://scrapegraphai.com/dashboard)
+Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
 </Note>
 
 <Accordion title="Example Response" icon="terminal">
 ```json
 {
-  "id": "0d6c4b31-931b-469b-9a7f-2f1e002e79ca",
-  "format": "markdown",
-  "content": [
-    "# Example Domain\n\nThis domain is for use in documentation examples..."
-  ],
+  "id": "03907b00-3c10-4b73-a6b5-e3b399a850b1",
+  "results": {
+    "markdown": {
+      "data": [
+        "# Example Domain\n\nThis domain is for use in documentation examples without needing permission. Avoid use in operations.\n\n[Learn more](https://iana.org/domains/example)\n"
+      ]
+    }
+  },
   "metadata": {
     "contentType": "text/html"
   }
@@ -94,72 +98,223 @@ Get your API key from the [dashboard](https://scrapegraphai.com/dashboard)
 
 ## Output Formats
 
-| Format | Description |
-|--------|-------------|
-| `markdown` | Clean markdown conversion of the page content (default). |
-| `html` | Raw HTML content of the page. |
-| `screenshot` | Screenshot image of the rendered page. |
-| `branding` | Brand design extraction: colors, fonts, typography, logos. |
+Pass an array of format objects. Each entry has a `type` and optional per-format options.
 
-## Advanced Usage
+| Format | Options | Description |
+|--------|---------|-------------|
+| `markdown` | `mode`: `"normal"` \| `"reader"` \| `"prune"` | Clean markdown conversion of the page. |
+| `html` | `mode`: `"normal"` \| `"reader"` \| `"prune"` | Raw or processed HTML. |
+| `links` | — | All outgoing links on the page. |
+| `images` | — | All image URLs on the page. |
+| `summary` | — | AI-generated short summary. |
+| `json` | `prompt`, `schema` | Structured JSON extraction (AI). |
+| `branding` | — | Brand colors, typography, and logos. |
+| `screenshot` | `fullPage`, `width`, `height`, `quality` | Screenshot image URL. |
 
-### With FetchConfig
+### Multi-format example
 
-```python
-from scrapegraph_py import Client, FetchConfig
+<CodeGroup>
 
-client = Client(api_key="your-api-key")
+```python Python
+from scrapegraph_py import (
+    ScrapeGraphAI,
+    ScrapeRequest,
+    MarkdownFormatConfig,
+    LinksFormatConfig,
+    ScreenshotFormatConfig,
+)
 
-response = client.scrape(
-    "https://example.com",
-    format="markdown",
+sgai = ScrapeGraphAI()
+
+res = sgai.scrape(ScrapeRequest(
+    url="https://example.com",
+    formats=[
+        MarkdownFormatConfig(mode="reader"),
+        LinksFormatConfig(),
+        ScreenshotFormatConfig(width=1280, height=720),
+    ],
+))
+
+if res.status == "success":
+    results = res.data.results
+    print("Markdown preview:", results["markdown"]["data"][0][:200])
+    print("Links count:", len(results["links"]["data"]))
+    print("Screenshot URL:", results["screenshot"]["data"]["url"])
+```
+
+```javascript JavaScript
+import { ScrapeGraphAI } from "scrapegraph-js";
+
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.scrape({
+  url: "https://example.com",
+  formats: [
+    { type: "markdown", mode: "reader" },
+    { type: "links" },
+    { type: "screenshot", fullPage: false, width: 1280, height: 720 },
+  ],
+});
+
+if (res.status === "success") {
+  const r = res.data?.results;
+  console.log("md:", r?.markdown?.data?.[0]?.slice(0, 200));
+  console.log("links:", r?.links?.metadata?.count);
+  console.log("screenshot:", r?.screenshot?.data?.url);
+}
+```
+
+```bash cURL
+curl -X POST https://v2-api.scrapegraphai.com/api/scrape \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "formats": [
+      { "type": "markdown", "mode": "reader" },
+      { "type": "links" },
+      { "type": "screenshot", "width": 1280, "height": 720 }
+    ]
+  }'
+```
+
+</CodeGroup>
+
+### Structured JSON extraction
+
+Use the `json` format to extract structured data during the scrape.
+
+<CodeGroup>
+
+```python Python
+from scrapegraph_py import ScrapeGraphAI, ScrapeRequest, JsonFormatConfig
+
+sgai = ScrapeGraphAI()
+
+res = sgai.scrape(ScrapeRequest(
+    url="https://scrapegraphai.com",
+    formats=[
+        JsonFormatConfig(
+            prompt="Extract the company name and tagline",
+            schema={
+                "type": "object",
+                "properties": {
+                    "companyName": {"type": "string"},
+                    "tagline": {"type": "string"},
+                },
+                "required": ["companyName"],
+            },
+        ),
+    ],
+))
+
+if res.status == "success":
+    print(res.data.results["json"]["data"])
+```
+
+```javascript JavaScript
+import { ScrapeGraphAI } from "scrapegraph-js";
+
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.scrape({
+  url: "https://scrapegraphai.com",
+  formats: [
+    {
+      type: "json",
+      prompt: "Extract the company name and tagline",
+      schema: {
+        type: "object",
+        properties: {
+          companyName: { type: "string" },
+          tagline: { type: "string" },
+        },
+        required: ["companyName"],
+      },
+    },
+  ],
+});
+
+if (res.status === "success") {
+  console.log(res.data?.results.json?.data);
+}
+```
+
+</CodeGroup>
+
+## FetchConfig
+
+Control how pages are fetched — JS rendering, stealth, custom headers, etc.
+
+<CodeGroup>
+
+```python Python
+from scrapegraph_py import ScrapeGraphAI, ScrapeRequest, MarkdownFormatConfig, FetchConfig
+
+sgai = ScrapeGraphAI()
+
+res = sgai.scrape(ScrapeRequest(
+    url="https://example.com",
+    formats=[MarkdownFormatConfig()],
     fetch_config=FetchConfig(
         mode="js",
         stealth=True,
         wait=2000,
+        scrolls=3,
         headers={"User-Agent": "MyBot"},
+        cookies={"session": "abc123"},
+        country="us",
     ),
-)
+))
 ```
 
-### Async Support
+```javascript JavaScript
+import { ScrapeGraphAI } from "scrapegraph-js";
+
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.scrape({
+  url: "https://example.com",
+  formats: [{ type: "markdown" }],
+  fetchConfig: {
+    mode: "js",
+    stealth: true,
+    wait: 2000,
+    scrolls: 3,
+    headers: { "User-Agent": "MyBot" },
+    cookies: { session: "abc123" },
+    country: "us",
+  },
+});
+```
+
+</CodeGroup>
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `mode` | string | Fetch mode: `"auto"` (default), `"fast"`, or `"js"`. |
+| `stealth` | bool | Enable stealth mode with residential proxy and anti-bot headers. |
+| `headers` | object | Custom HTTP headers. |
+| `cookies` | object | Cookies to include in the request. |
+| `scrolls` | int | Number of page scrolls (0–100). |
+| `wait` | int | Milliseconds to wait after page load (0–30000). |
+| `timeout` | int | Request timeout in milliseconds (1000–60000). |
+| `country` | string | Two-letter ISO country code for geo-targeted proxy routing. |
+
+## Async Support (Python)
 
 ```python
 import asyncio
-from scrapegraph_py import AsyncClient
+from scrapegraph_py import AsyncScrapeGraphAI, ScrapeRequest, MarkdownFormatConfig
 
 async def main():
-    async with AsyncClient(api_key="your-api-key") as client:
-        response = await client.scrape("https://example.com")
-        print(response)
-
-asyncio.run(main())
-```
-
-### Concurrent Processing
-
-Process multiple URLs concurrently for better performance:
-
-```python
-import asyncio
-from scrapegraph_py import AsyncClient
-
-async def main():
-    async with AsyncClient(api_key="your-api-key") as client:
-        urls = [
-            "https://example.com",
-            "https://scrapegraphai.com/",
-            "https://github.com/ScrapeGraphAI/Scrapegraph-ai",
-        ]
-
-        tasks = [client.scrape(url) for url in urls]
-        responses = await asyncio.gather(*tasks, return_exceptions=True)
-
-        for i, response in enumerate(responses):
-            if isinstance(response, Exception):
-                print(f"Error for {urls[i]}: {response}")
-            else:
-                print(f"Page {i+1}: {len(str(response))} characters")
+    async with AsyncScrapeGraphAI() as sgai:
+        res = await sgai.scrape(ScrapeRequest(
+            url="https://example.com",
+            formats=[MarkdownFormatConfig()],
+        ))
+        if res.status == "success":
+            print(res.data.results["markdown"]["data"][0])
 
 asyncio.run(main())
 ```
@@ -168,28 +323,28 @@ asyncio.run(main())
 
 <CardGroup cols={2}>
   <Card title="Multiple Formats" icon="file-lines">
-    Get content as markdown, HTML, screenshot, or branding data
+    Request any combination of markdown, HTML, links, images, summary, JSON, branding, or screenshots in a single call.
   </Card>
   <Card title="JavaScript Rendering" icon="code">
-    Handle JavaScript-heavy sites with `mode: "js"` fetch mode
+    Handle JavaScript-heavy sites with `mode: "js"` on `fetchConfig`.
   </Card>
-  <Card title="Fast Processing" icon="clock">
-    Quick extraction for simple content
+  <Card title="Structured Output" icon="table">
+    Use the `json` format with a JSON schema to get typed data back.
   </Card>
   <Card title="Reliable Output" icon="shield-check">
-    Consistent results across different websites
+    Stealth mode and country-targeted proxies for difficult sources.
   </Card>
 </CardGroup>
 
 ## Integration Options
 
 ### Official SDKs
-- [Python SDK](/sdks/python) - Perfect for automation and data processing
-- [JavaScript SDK](/sdks/javascript) - Ideal for web applications and browser tools
+- [Python SDK](/sdks/python) — perfect for automation and data processing
+- [JavaScript SDK](/sdks/javascript) — ideal for web applications and Node.js (≥ 22)
 
 ### AI Framework Integrations
-- [LangChain Integration](/integrations/langchain) - Use Scrape in your content pipelines
-- [LlamaIndex Integration](/integrations/llamaindex) - Create searchable knowledge bases
+- [LangChain Integration](/integrations/langchain) — use Scrape in your content pipelines
+- [LlamaIndex Integration](/integrations/llamaindex) — create searchable knowledge bases
 
 ## Support & Resources
 

--- a/services/search.mdx
+++ b/services/search.mdx
@@ -6,10 +6,10 @@ icon: 'magnifying-glass'
 
 ## Overview
 
-Search enables you to search the web and extract structured results using AI. It combines web search capabilities with intelligent data extraction, returning clean, structured data from search results.
+Search runs a web query and returns the top results with their content already fetched. Optionally add a `prompt` and `schema` to have the results summarised into structured JSON.
 
 <Note>
-Try Search instantly in our [interactive playground](https://scrapegraphai.com/dashboard) 
+Try Search instantly in our [interactive playground](https://scrapegraphai.com/dashboard).
 </Note>
 
 ## Getting Started
@@ -19,35 +19,47 @@ Try Search instantly in our [interactive playground](https://scrapegraphai.com/d
 <CodeGroup>
 
 ```python Python
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, SearchRequest
 
-client = Client(api_key="your-api-key")
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
 
-response = client.search(
-    query="What are the key features of ChatGPT Plus?"
-)
+res = sgai.search(SearchRequest(
+    query="best programming languages 2024",
+    num_results=3,
+))
+
+if res.status == "success":
+    for r in res.data.results:
+        print(r.title, "-", r.url)
+else:
+    print("Failed:", res.error)
 ```
 
 ```javascript JavaScript
-import { search } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await search('your-api-key', {
-  query: 'What are the key features of ChatGPT Plus?',
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.search({
+  query: "best programming languages 2024",
+  numResults: 3,
 });
 
-if (result.status === 'success') {
-  for (const r of result.data?.results ?? []) {
+if (res.status === "success") {
+  for (const r of res.data?.results ?? []) {
     console.log(`${r.title} - ${r.url}`);
   }
 }
 ```
 
 ```bash cURL
-curl -X POST https://api.scrapegraphai.com/api/v2/search \
+curl -X POST https://v2-api.scrapegraphai.com/api/search \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-api-key" \
   -d '{
-    "query": "What are the key features of ChatGPT Plus?"
+    "query": "best programming languages 2024",
+    "numResults": 3
   }'
 ```
 
@@ -57,80 +69,111 @@ curl -X POST https://api.scrapegraphai.com/api/v2/search \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| query | string | Yes | The search query to execute. |
-| num_results | int | No | Number of search results to return (1-20). Default: 5. |
-| prompt | string | No | Prompt used when extracting structured results. |
-| output_schema | object | No | Pydantic or Zod schema for structured response format (requires `prompt`). |
-| format | string | No | Output format: `"markdown"` (default) or `"html"`. |
-| mode | string | No | HTML processing mode: `"normal"`, `"reader"`, `"prune"` (default). |
-| country | string | No | Two-letter ISO country code for localized results (e.g. `"us"`, `"it"`, `"gb"`). |
-| time_range | string | No | Recency filter: `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"`. |
-| fetch_config | FetchConfig | No | Configuration for page fetching (mode, stealth, headers, etc.). |
+| `query` | string | Yes | The search query. |
+| `numResults` / `num_results` | int | No | Number of results (1–20). Default: `3`. |
+| `prompt` | string | No | Prompt used for AI extraction across the fetched results. |
+| `schema` | object | No | JSON schema for structured output (requires `prompt`). |
+| `format` | string | No | Output format for page content: `"markdown"` (default) or `"html"`. |
+| `timeRange` / `time_range` | string | No | Recency filter: `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"`. |
+| `locationGeoCode` / `location_geo_code` | string | No | Two-letter ISO country code for localized results (e.g. `"us"`, `"it"`). |
+| `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>
-Get your API key from the [dashboard](https://scrapegraphai.com/dashboard)
+Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
 </Note>
 
-## Custom Schema Example
+## Search + Extraction
 
-Define the structure of the output using Pydantic or Zod:
+Combine search with AI extraction to roll results into one structured output.
 
 <CodeGroup>
 
 ```python Python
-from pydantic import BaseModel, Field
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, SearchRequest
 
-class SearchResult(BaseModel):
-    title: str = Field(description="The result title")
-    summary: str = Field(description="Brief summary of the result")
-    url: str = Field(description="Source URL")
+sgai = ScrapeGraphAI()
 
-client = Client(api_key="your-api-key")
+res = sgai.search(SearchRequest(
+    query="best programming languages 2024",
+    num_results=3,
+    prompt="Summarize the top languages and why they are recommended",
+    schema={
+        "type": "object",
+        "properties": {
+            "languages": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                },
+            },
+        },
+    },
+))
 
-response = client.search(
-    query="Latest AI developments 2024",
-    num_results=10,
-    output_schema=SearchResult,
-)
+if res.status == "success":
+    print(res.data.json_data)
 ```
 
 ```javascript JavaScript
-import { search } from 'scrapegraph-js';
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await search('your-api-key', {
-  query: 'Latest AI developments 2024',
-  numResults: 10,
-  prompt: 'Extract the title, summary, and source URL',
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.search({
+  query: "typescript best practices",
+  numResults: 5,
+  prompt: "Extract the main tips and recommendations",
   schema: {
-    type: 'object',
+    type: "object",
     properties: {
-      title: { type: 'string' },
-      summary: { type: 'string' },
-      url: { type: 'string' },
+      tips: { type: "array", items: { type: "string" } },
     },
   },
 });
 
-if (result.status === 'success') {
-  console.log(result.data?.json);
+if (res.status === "success") {
+  console.log(res.data?.json);
 }
+```
+
+```bash cURL
+curl -X POST https://v2-api.scrapegraphai.com/api/search \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "typescript best practices",
+    "numResults": 5,
+    "prompt": "Extract the main tips and recommendations",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "tips": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }'
 ```
 
 </CodeGroup>
 
-## Async Support
+## Async Support (Python)
 
 ```python
 import asyncio
-from scrapegraph_py import AsyncClient
+from scrapegraph_py import AsyncScrapeGraphAI, SearchRequest
 
 async def main():
-    async with AsyncClient(api_key="your-api-key") as client:
-        response = await client.search(
-            query="Best practices for web scraping"
-        )
-        print(response)
+    async with AsyncScrapeGraphAI() as sgai:
+        res = await sgai.search(SearchRequest(
+            query="Best practices for web scraping",
+            num_results=5,
+        ))
+        if res.status == "success":
+            for r in res.data.results:
+                print(r.title, "-", r.url)
 
 asyncio.run(main())
 ```
@@ -139,34 +182,34 @@ asyncio.run(main())
 
 <CardGroup cols={2}>
   <Card title="AI-Powered Search" icon="brain">
-    Intelligent extraction from search results
+    Search + content extraction in one call.
   </Card>
   <Card title="Structured Output" icon="table">
-    Returns clean, structured data in your preferred format
+    Add a prompt and schema for typed JSON.
   </Card>
-  <Card title="Schema Support" icon="code">
-    Define custom output schemas using Pydantic or Zod
+  <Card title="Localized Results" icon="globe">
+    Use `locationGeoCode` for country-specific results.
   </Card>
-  <Card title="Flexible Results" icon="sliders">
-    Control the number of search results returned
+  <Card title="Time Filters" icon="clock">
+    Narrow to the past hour, day, week, month, or year.
   </Card>
 </CardGroup>
 
 ## Integration Options
 
 ### Official SDKs
-- [Python SDK](/sdks/python) - Perfect for data science and backend applications
-- [JavaScript SDK](/sdks/javascript) - Ideal for web applications and Node.js
+- [Python SDK](/sdks/python)
+- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
 
 ### AI Framework Integrations
-- [LangChain Integration](/integrations/langchain) - Use Search in your LLM workflows
-- [LlamaIndex Integration](/integrations/llamaindex) - Build powerful search and QA systems
+- [LangChain Integration](/integrations/langchain)
+- [LlamaIndex Integration](/integrations/llamaindex)
 
 ## Support & Resources
 
 <CardGroup cols={2}>
   <Card title="Documentation" icon="book" href="/introduction">
-    Comprehensive guides and tutorials
+    Guides and tutorials
   </Card>
   <Card title="API Reference" icon="code" href="/api-reference/introduction">
     Detailed API documentation

--- a/services/search.mdx
+++ b/services/search.mdx
@@ -199,7 +199,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain)

--- a/transition-from-v1-to-v2.mdx
+++ b/transition-from-v1-to-v2.mdx
@@ -231,7 +231,7 @@ Exact paths and payloads are listed under each service (for example [Scrape](/se
 1. Log in at [scrapegraphai.com/login](https://scrapegraphai.com/login)
 2. Start from [Introduction](/introduction)
 3. Follow [Installation](/install)
-4. Upgrade packages: `pip install -U scrapegraph-py` / `npm i scrapegraph-js@latest` (Node **≥ 22** for JS v2)
+4. Upgrade packages: `pip install -U scrapegraph-py` / `npm i scrapegraph-js@latest` (requires **`scrapegraph-js` ≥ 2.0.1** and **Node ≥ 22**)
 
 ## SDK migration guides (detailed changelogs)
 

--- a/transition-from-v1-to-v2.mdx
+++ b/transition-from-v1-to-v2.mdx
@@ -39,27 +39,33 @@ Use this table to map old entry points to new ones. Details and examples follow 
 <CodeGroup>
 
 ```python Python (v2)
-from scrapegraph_py import Client
+from scrapegraph_py import ScrapeGraphAI, ScrapeRequest, MarkdownFormatConfig
 
-client = Client(api_key="your-api-key")
-response = client.scrape(
-    "https://example.com",
-    format="markdown",
-)
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
 
-print(response)
+res = sgai.scrape(ScrapeRequest(
+    url="https://example.com",
+    formats=[MarkdownFormatConfig()],
+))
+
+if res.status == "success":
+    print(res.data.results["markdown"]["data"][0])
 ```
 
 ```javascript JavaScript (v2)
-import { scrape } from "scrapegraph-js";
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await scrape(apiKey, {
+// reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI({ apiKey: "..." })
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.scrape({
   url: "https://example.com",
   formats: [{ type: "markdown" }],
 });
 
-if (result.status === "success") {
-  console.log(result.data?.results.markdown?.data);
+if (res.status === "success") {
+  console.log(res.data?.results.markdown?.data?.[0]);
 }
 ```
 
@@ -85,14 +91,17 @@ response = client.smartscraper(
 ```
 
 ```python Python (v2)
-from scrapegraph_py import Client, FetchConfig
+from scrapegraph_py import ScrapeGraphAI, ExtractRequest, FetchConfig
 
-client = Client(api_key="your-api-key")
-response = client.extract(
+sgai = ScrapeGraphAI()
+res = sgai.extract(ExtractRequest(
     url="https://example.com",
     prompt="Extract the title and price",
     fetch_config=FetchConfig(stealth=True),
-)
+))
+
+if res.status == "success":
+    print(res.data.json_data)
 ```
 
 ```javascript JavaScript (v1)
@@ -106,15 +115,17 @@ const response = await smartScraper(apiKey, {
 ```
 
 ```javascript JavaScript (v2)
-import { extract } from "scrapegraph-js";
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await extract(apiKey, {
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.extract({
   url: "https://example.com",
   prompt: "Extract the title and price",
 });
 
-if (result.status === "success") {
-  console.log(result.data?.json);
+if (res.status === "success") {
+  console.log(res.data?.json);
 }
 ```
 
@@ -129,19 +140,32 @@ if (result.status === "success") {
 <CodeGroup>
 
 ```python Python (v2)
-response = client.search(
+from scrapegraph_py import ScrapeGraphAI, SearchRequest
+
+sgai = ScrapeGraphAI()
+res = sgai.search(SearchRequest(
     query="Latest pricing for product X",
     num_results=5,
-)
+))
+
+if res.status == "success":
+    for r in res.data.results:
+        print(r.title, "-", r.url)
 ```
 
 ```javascript JavaScript (v2)
-import { search } from "scrapegraph-js";
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const result = await search(apiKey, {
+const sgai = ScrapeGraphAI();
+
+const res = await sgai.search({
   query: "Latest pricing for product X",
   numResults: 5,
 });
+
+if (res.status === "success") {
+  for (const r of res.data?.results ?? []) console.log(r.title, "-", r.url);
+}
 ```
 
 </CodeGroup>
@@ -155,25 +179,33 @@ const result = await search(apiKey, {
 <CodeGroup>
 
 ```python Python (v2)
-job = client.crawl.start(
+from scrapegraph_py import ScrapeGraphAI, CrawlRequest
+
+sgai = ScrapeGraphAI()
+
+start = sgai.crawl.start(CrawlRequest(
     url="https://example.com",
-    depth=2,
+    max_depth=2,
     include_patterns=["/blog/*"],
     exclude_patterns=["/admin/*"],
-)
-status = client.crawl.status(job["id"])
+))
+
+status = sgai.crawl.get(start.data.id)
+print(status.data.status, status.data.finished, "/", status.data.total)
 ```
 
 ```javascript JavaScript (v2)
-import { crawl } from "scrapegraph-js";
+import { ScrapeGraphAI } from "scrapegraph-js";
 
-const job = await crawl.start(apiKey, {
+const sgai = ScrapeGraphAI();
+
+const start = await sgai.crawl.start({
   url: "https://example.com",
   maxDepth: 2,
   includePatterns: ["/blog/*"],
   excludePatterns: ["/admin/*"],
 });
-const status = await crawl.get(apiKey, job.data?.id);
+const status = await sgai.crawl.get(start.data.id);
 ```
 
 </CodeGroup>
@@ -182,9 +214,9 @@ const status = await crawl.get(apiKey, job.data?.id);
 
 If you call the API with `curl` or a generic HTTP client:
 
-- Use the v2 host and path pattern: **`https://api.scrapegraphai.com/api/v2/<endpoint>`** (e.g. `/api/v2/scrape`, `/api/v2/extract`, `/api/v2/search`, `/api/v2/crawl`, `/api/v2/monitor`).
-- Replace JSON fields to match v2 bodies (e.g. `url` and `prompt` instead of `website_url` and `user_prompt` on extract).
-- Keep using the **`SGAI-APIKEY`** header unless the endpoint docs specify otherwise.
+- Use the v2 host and path pattern: **`https://v2-api.scrapegraphai.com/api/<endpoint>`** (e.g. `/api/scrape`, `/api/extract`, `/api/search`, `/api/crawl`, `/api/monitor`).
+- Replace JSON fields to match v2 bodies (e.g. `url` and `prompt` instead of `website_url` and `user_prompt` on extract; `formats: [{ type: "markdown" }]` instead of `format: "markdown"`).
+- Authenticate with the **`SGAI-APIKEY`** header.
 
 Exact paths and payloads are listed under each service (for example [Scrape](/services/scrape)) and in the [API reference](/api-reference/introduction).
 


### PR DESCRIPTION
## Summary

Realigns the docs with the current [`scrapegraph-py@2.x`](https://github.com/ScrapeGraphAI/scrapegraph-py) and [`scrapegraph-js@2.x`](https://github.com/ScrapeGraphAI/scrapegraph-js) SDK READMEs and examples.

### What changed

- **New SDK entry points**: replaced `Client(api_key=...)` / `import { scrape } from "scrapegraph-js"; scrape(apiKey, {...})` with `ScrapeGraphAI()` factory (Python) and `ScrapeGraphAI()` factory (JS). Both SDKs auto-read `SGAI_API_KEY` from env.
- **Typed request models** in Python snippets: `ScrapeRequest`, `ExtractRequest`, `SearchRequest`, `CrawlRequest`, `MonitorCreateRequest`, `MonitorUpdateRequest`, `MonitorActivityRequest`, `HistoryFilter`.
- **Per-format configs** replace the old `format="markdown"` string: `MarkdownFormatConfig`, `LinksFormatConfig`, `ScreenshotFormatConfig`, `JsonFormatConfig`, etc. JS uses `formats: [{ type: "markdown", mode: "reader" }, ...]`.
- **`ApiResult<T>` return shape** (`status`, `data`, `error`, `elapsedMs`/`elapsed_ms`) — no exceptions.
- **cURL fixes**: base URL is now `https://v2-api.scrapegraphai.com/api/<endpoint>` (was `api.scrapegraphai.com/api/v2`), auth header is `SGAI-APIKEY` (was `Authorization: Bearer`). The previous values are rejected by the live v2 API.
- **Environment variables table**: corrected `SGAI_API_URL` default on both SDK pages.
- **Monitor** page rewritten around `sgai.monitor.create/list/get/update/pause/resume/delete/activity`.

### Files touched

- `services/scrape.mdx`
- `services/extract.mdx`
- `services/search.mdx`
- `services/crawl.mdx`
- `services/monitor.mdx`
- `sdks/python.mdx`
- `sdks/javascript.mdx`
- `transition-from-v1-to-v2.mdx`

## Live API test results

Every Python, JavaScript, and cURL snippet in the updated files was run against `https://v2-api.scrapegraphai.com/api` before commit. Environment: `scrapegraph-py==2.0.1`, `scrapegraph-js@2.0.1`, Node 22.22.1, Python 3.13.

| File | Python | JavaScript | cURL |
|---|:-:|:-:|:-:|
| `services/scrape.mdx` — basic, multi-format, JSON extraction, fetch_config, async | pass | pass | pass |
| `services/extract.mdx` — basic, schema, from HTML, async | pass | pass | pass |
| `services/search.mdx` — basic, + extraction, async | pass | pass | pass |
| `services/crawl.mdx` — `start` → `get`, async | pass | pass | pass |
| `services/monitor.mdx` — `create`, `list`, `get`, `update`, `pause`, `resume`, `activity`, `delete` | pass | pass | pass |
| `sdks/python.mdx` — full page sweep (quickstart, scrape, extract, search, crawl, monitor, history, credits, health) | pass | — | — |
| `sdks/javascript.mdx` — full page sweep (quickstart, scrape, extract, search, crawl, monitor, history, credits, healthy) | — | pass | — |
| `transition-from-v1-to-v2.mdx` — scrape, extract, search, crawl | pass | pass | — |

Representative responses captured during the sweep:
- `GET /credits` → `{"remaining":999994,"used":410,"plan":"Test Plan","jobs":{"crawl":{"used":0,"limit":50},"monitor":{"used":1,"limit":100}}}`
- `POST /scrape` (markdown) → returns `results.markdown.data[0]` with the Example Domain body
- `POST /scrape` (screenshot) → returns `results.screenshot.data.url` (signed R2 URL)
- `POST /extract` (schema) → returns typed `json` with `usage.promptTokens`/`completionTokens`
- `POST /crawl` → returns `{id, status: "running", total, finished, pages}`
- `POST /monitor` → returns `{cronId, scheduleId, interval, status: "active", config, createdAt, updatedAt}`

### Known live-API quirk (unchanged in this PR)

- `format: "branding"` on `/scrape` against `https://scrapegraphai.com` currently returns `500 {"error":{"type":"internal","message":"Internal server error"}}`. Left as-is in the docs since it's a backend issue, not a snippet issue.

## Test plan

- [x] Run every Python snippet against live API
- [x] Run every JavaScript snippet against live API (Node 22)
- [x] Run every cURL snippet against live API
- [x] Review rendered MDX on Mintlify preview
- [x] Verify no broken links in the updated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)