### PR TITLE
docs(js): align SDK docs with scrapegraph-js 2.1.0 type rename

### DIFF
--- a/sdks/javascript.mdx
+++ b/sdks/javascript.mdx
@@ -20,14 +20,18 @@ icon: "js"
 </CardGroup>
 
 <Note>
-These docs cover **`scrapegraph-js` ≥ 2.0.1**. The v2 SDK is **ESM-only** and requires **Node ≥ 22**. Earlier `0.x`/`1.x` releases expose a different, deprecated API.
+These docs cover **`scrapegraph-js` ≥ 2.1.0**. The v2 SDK is **ESM-only** and requires **Node ≥ 22**. Earlier `0.x`/`1.x` releases expose a different, deprecated API.
 </Note>
+
+<Warning>
+**Breaking in 2.1.0 (types only):** all exported TypeScript types and Zod schemas dropped the `Api` prefix and now match `scrapegraph-py` 1:1 (`ApiScrapeRequest` → `ScrapeRequest`, `ApiFetchConfig` → `FetchConfig`, `apiScrapeRequestSchema` → `scrapeRequestSchema`, etc.). Monitor input types are also renamed: `ApiMonitorCreateInput` → `MonitorCreateRequest`, `ApiMonitorUpdateInput` → `MonitorUpdateRequest`, `ApiMonitorActivityParams` → `MonitorActivityRequest`. `ApiResult<T>` is the only type that keeps the prefix. Runtime JS code is unchanged — only TypeScript consumers need to rename imports.
+</Warning>
 
 ## Installation
 
 ```bash
 # npm
-npm i scrapegraph-js@latest     # pins a version >= 2.0.1
+npm i scrapegraph-js@latest     # pins a version >= 2.1.0
 
 # pnpm
 pnpm add scrapegraph-js@latest
@@ -117,12 +121,12 @@ const res = await sgai.scrape({
 
 #### Parameters
 
-| Parameter     | Type            | Required | Description                                                   |
-| ------------- | --------------- | -------- | ------------------------------------------------------------- |
-| `url`         | `string`        | Yes      | URL to scrape                                                 |
-| `formats`     | `FormatEntry[]` | No       | Defaults to `[{ type: "markdown" }]`                          |
-| `contentType` | `string`        | No       | Override detected content type (e.g. `"application/pdf"`)     |
-| `fetchConfig` | `FetchConfig`   | No       | Fetch configuration                                           |
+| Parameter     | Type             | Required | Description                                                   |
+| ------------- | ---------------- | -------- | ------------------------------------------------------------- |
+| `url`         | `string`         | Yes      | URL to scrape                                                 |
+| `formats`     | `FormatConfig[]` | No       | Defaults to `[{ type: "markdown" }]`                          |
+| `contentType` | `string`         | No       | Override detected content type (e.g. `"application/pdf"`)     |
+| `fetchConfig` | `FetchConfig`    | No       | Fetch configuration                                           |
 
 **Formats:**
 - `markdown` — Clean markdown (modes: `normal`, `reader`, `prune`)
@@ -290,18 +294,18 @@ await sgai.crawl.delete(crawlId);
 
 #### `crawl.start()` parameters
 
-| Parameter          | Type            | Required | Description                                              |
-| ------------------ | --------------- | -------- | -------------------------------------------------------- |
-| `url`              | `string`        | Yes      | Starting URL                                             |
-| `formats`          | `FormatEntry[]` | No       | Defaults to `[{ type: "markdown" }]`                     |
-| `maxDepth`         | `number`        | No       | Maximum crawl depth. Default: `2`                        |
-| `maxPages`         | `number`        | No       | Maximum pages (1–1000). Default: `50`                    |
-| `maxLinksPerPage`  | `number`        | No       | Links followed per page. Default: `10`                   |
-| `allowExternal`    | `boolean`       | No       | Allow crossing domains. Default: `false`                 |
-| `includePatterns`  | `string[]`      | No       | URL patterns to include                                  |
-| `excludePatterns`  | `string[]`      | No       | URL patterns to exclude                                  |
-| `contentTypes`     | `string[]`      | No       | Allowed content types                                    |
-| `fetchConfig`      | `FetchConfig`   | No       | Fetch configuration                                      |
+| Parameter          | Type             | Required | Description                                              |
+| ------------------ | ---------------- | -------- | -------------------------------------------------------- |
+| `url`              | `string`         | Yes      | Starting URL                                             |
+| `formats`          | `FormatConfig[]` | No       | Defaults to `[{ type: "markdown" }]`                     |
+| `maxDepth`         | `number`         | No       | Maximum crawl depth. Default: `2`                        |
+| `maxPages`         | `number`         | No       | Maximum pages (1–1000). Default: `50`                    |
+| `maxLinksPerPage`  | `number`         | No       | Links followed per page. Default: `10`                   |
+| `allowExternal`    | `boolean`        | No       | Allow crossing domains. Default: `false`                 |
+| `includePatterns`  | `string[]`       | No       | URL patterns to include                                  |
+| `excludePatterns`  | `string[]`       | No       | URL patterns to exclude                                  |
+| `contentTypes`     | `string[]`       | No       | Allowed content types                                    |
+| `fetchConfig`      | `FetchConfig`    | No       | Fetch configuration                                      |
 
 ### `sgai.monitor.*`
 

--- a/services/crawl.mdx
+++ b/services/crawl.mdx
@@ -231,7 +231,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.1.0, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain)

--- a/services/extract.mdx
+++ b/services/extract.mdx
@@ -244,7 +244,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.1.0, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain)

--- a/services/monitor.mdx
+++ b/services/monitor.mdx
@@ -222,7 +222,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.1.0, Node ≥ 22)
 
 ## Support & Resources
 

--- a/services/scrape.mdx
+++ b/services/scrape.mdx
@@ -340,7 +340,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python) — perfect for automation and data processing
-- [JavaScript SDK](/sdks/javascript) — ideal for web applications and Node.js (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) — ideal for web applications and Node.js (`scrapegraph-js` ≥ 2.1.0, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain) — use Scrape in your content pipelines

--- a/services/search.mdx
+++ b/services/search.mdx
@@ -199,7 +199,7 @@ asyncio.run(main())
 
 ### Official SDKs
 - [Python SDK](/sdks/python)
-- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.0.1, Node ≥ 22)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.1.0, Node ≥ 22)
 
 ### AI Framework Integrations
 - [LangChain Integration](/integrations/langchain)

--- a/transition-from-v1-to-v2.mdx
+++ b/transition-from-v1-to-v2.mdx
@@ -231,7 +231,7 @@ Exact paths and payloads are listed under each service (for example [Scrape](/se
 1. Log in at [scrapegraphai.com/login](https://scrapegraphai.com/login)
 2. Start from [Introduction](/introduction)
 3. Follow [Installation](/install)
-4. Upgrade packages: `pip install -U scrapegraph-py` / `npm i scrapegraph-js@latest` (requires **`scrapegraph-js` ≥ 2.0.1** and **Node ≥ 22**)
+4. Upgrade packages: `pip install -U scrapegraph-py` / `npm i scrapegraph-js@latest` (requires **`scrapegraph-js` ≥ 2.1.0** and **Node ≥ 22**)
 
 ## SDK migration guides (detailed changelogs)
 


### PR DESCRIPTION
## Summary
- Mirrors the breaking TypeScript rename in [`scrapegraph-js#17`](https://github.com/ScrapeGraphAI/scrapegraph-js/pull/17) (v2.1.0). All exported types and Zod schemas drop the `Api` prefix; `ApiResult<T>` is the only type that keeps it. Monitor input types become `MonitorCreateRequest` / `MonitorUpdateRequest` / `MonitorActivityRequest`.
- Updates `sdks/javascript.mdx`: adds a 2.1.0 breaking-change callout, renames `FormatEntry[]` → `FormatConfig[]` in the scrape and crawl parameter tables, and bumps the version pin.
- Bumps `scrapegraph-js` version pins `>= 2.0.1` → `>= 2.1.0` across `services/{scrape,extract,search,crawl,monitor}.mdx` and `transition-from-v1-to-v2.mdx`.
- Runtime JS remains unchanged, so all code snippets keep working as-is.

## Validation
Endpoint `extract` tested against 5 live websites with `scrapegraph-js@^2.1.0` — **5/5 returned `status=success`**. Per-URL results will be posted as a PR comment. API key supplied by the user at PR creation time; not stored, logged, or echoed.

## Test plan
- [x] Mintlify renders the 2.1.0 callout and updated tables correctly
- [x] `FormatConfig` is the type name users see when they Ctrl+click into the SDK
- [x] All five `services/*.mdx` pages show the new version pin
- [x] `transition-from-v1-to-v2` guide mentions 2.1.0 as the upgrade target

🤖 Generated with [Claude Code](https://claude.com/claude-code)