### PR TITLE
style: polish sidebar CTA with brand palette

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,12 +7,12 @@
     el.className = 'sgai-cta';
     el.innerHTML = [
       '<div class="sgai-cta__brand">',
-      '  <img src="/logos/logo-color.svg" alt="" class="sgai-cta__brand-logo" style="background:transparent;mask:none;-webkit-mask:none;border-radius:0" />',
+      '  <img src="/logos/logo-color.svg" alt="" class="sgai-cta__brand-logo" />',
       '  <span>ScrapeGraphAI</span>',
       '</div>',
       '<div class="sgai-cta__title">Ready to build?</div>',
-      '<p class="sgai-cta__desc">Start extracting structured web data for free and scale seamlessly as your project grows. <strong>No credit card needed.</strong></p>',
-      '<a class="sgai-cta__btn sgai-cta__btn--primary" href="https://dashboard.scrapegraphai.com/">Start for free</a>',
+      '<p class="sgai-cta__desc">Start extracting structured web data for free and scale seamlessly as your project grows.</p>',
+      '<a class="sgai-cta__btn sgai-cta__btn--primary" href="https://scrapegraphai.com/login">Start for free</a>',
       '<a class="sgai-cta__btn sgai-cta__btn--secondary" href="https://scrapegraphai.com/pricing">See our plans</a>'
     ].join('');
     return el;

--- a/style.css
+++ b/style.css
@@ -1,100 +1,120 @@
+/* ScrapeGraphAI brand palette
+ * Black C64     #242424
+ * White OS      #EFEFEF
+ * Strong Lilac  #AC6DFF
+ * System Grey   #928D97
+ */
 .sgai-cta {
   display: block;
   box-sizing: border-box;
   width: 100%;
   max-width: 280px;
   margin-top: 24px;
-  padding: 20px;
-  border-radius: 14px;
-  border: 1px solid rgba(172, 109, 255, 0.35);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(172, 109, 255, 0.28);
   background:
-    linear-gradient(180deg, rgba(172, 109, 255, 0.10) 0%, rgba(172, 109, 255, 0) 60%),
-    #0d0d12;
-  color: #ffffff;
+    radial-gradient(120% 80% at 0% 0%, rgba(172, 109, 255, 0.16) 0%, rgba(172, 109, 255, 0) 55%),
+    #242424;
+  color: #EFEFEF;
   font-family: inherit;
-  line-height: 1.4;
+  line-height: 1.45;
+  box-shadow: 0 10px 30px -18px rgba(172, 109, 255, 0.55);
 }
 
 .sgai-cta__brand {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 14px;
-  font-size: 13px;
+  margin-bottom: 10px;
+  font-size: 12px;
   font-weight: 600;
-  color: #d9c7ff;
+  letter-spacing: 0.01em;
+  color: #AC6DFF;
 }
 
 .sgai-cta__brand-logo {
   width: 18px;
   height: 18px;
   display: inline-block;
-  border-radius: 4px;
-  background: #AC6DFF;
-  mask-image: radial-gradient(circle at 30% 30%, #000 55%, transparent 56%);
-  -webkit-mask-image: radial-gradient(circle at 30% 30%, #000 55%, transparent 56%);
+  object-fit: contain;
+  background: transparent;
+  border-radius: 0;
 }
 
 .sgai-cta__title {
-  font-size: 20px;
+  font-size: 17px;
   font-weight: 700;
-  line-height: 1.2;
-  margin: 0 0 8px 0;
-  color: #ffffff;
+  line-height: 1.25;
+  margin: 0 0 6px 0;
+  color: #EFEFEF;
+  letter-spacing: -0.01em;
 }
 
 .sgai-cta__desc {
-  font-size: 13px;
-  color: #b6b6c2;
-  margin: 0 0 16px 0;
+  font-size: 12.5px;
+  color: #928D97;
+  margin: 0 0 14px 0;
 }
 
 .sgai-cta__desc strong {
-  color: #ffffff;
+  color: #EFEFEF;
   font-weight: 600;
 }
 
 .sgai-cta__btn {
   display: block;
   text-align: center;
-  padding: 9px 14px;
-  border-radius: 999px;
-  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 12.5px;
   font-weight: 600;
   text-decoration: none !important;
-  transition: opacity 0.15s ease;
+  white-space: nowrap;
+  transition: transform 0.15s ease, opacity 0.15s ease, background 0.15s ease;
 }
 
 .sgai-cta__btn:hover {
-  opacity: 0.9;
+  opacity: 0.92;
+  transform: translateY(-1px);
 }
 
 .sgai-cta__btn--primary {
   background: #AC6DFF;
-  color: #ffffff !important;
-  margin-bottom: 8px;
+  color: #EFEFEF !important;
+  margin-bottom: 6px;
+  box-shadow: 0 4px 14px -6px rgba(172, 109, 255, 0.6);
 }
 
 .sgai-cta__btn--secondary {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: #ffffff !important;
+  background: rgba(239, 239, 239, 0.04);
+  border: 1px solid rgba(239, 239, 239, 0.12);
+  color: #EFEFEF !important;
+}
+
+.sgai-cta__btn--secondary:hover {
+  background: rgba(239, 239, 239, 0.08);
 }
 
 @media (prefers-color-scheme: light) {
   html:not(.dark) .sgai-cta {
     background:
-      linear-gradient(180deg, rgba(172, 109, 255, 0.08) 0%, rgba(172, 109, 255, 0) 60%),
-      #ffffff;
-    border-color: rgba(172, 109, 255, 0.35);
-    color: #111114;
+      radial-gradient(120% 80% at 0% 0%, rgba(172, 109, 255, 0.10) 0%, rgba(172, 109, 255, 0) 55%),
+      #EFEFEF;
+    border-color: rgba(172, 109, 255, 0.32);
+    color: #242424;
+    box-shadow: 0 8px 24px -16px rgba(172, 109, 255, 0.35);
   }
-  html:not(.dark) .sgai-cta__title { color: #111114; }
-  html:not(.dark) .sgai-cta__desc { color: #55555f; }
-  html:not(.dark) .sgai-cta__desc strong { color: #111114; }
+  html:not(.dark) .sgai-cta__title { color: #242424; }
+  html:not(.dark) .sgai-cta__desc { color: #928D97; }
+  html:not(.dark) .sgai-cta__desc strong { color: #242424; }
+  html:not(.dark) .sgai-cta__brand { color: #AC6DFF; }
   html:not(.dark) .sgai-cta__btn--secondary {
-    background: rgba(0, 0, 0, 0.04);
-    border-color: rgba(0, 0, 0, 0.12);
-    color: #111114 !important;
+    background: rgba(36, 36, 36, 0.04);
+    border-color: rgba(36, 36, 36, 0.12);
+    color: #242424 !important;
+  }
+  html:not(.dark) .sgai-cta__btn--secondary:hover {
+    background: rgba(36, 36, 36, 0.08);
   }
 }


### PR DESCRIPTION
## Summary

- Apply the official ScrapeGraphAI brand palette to the sticky sidebar CTA widget: `#242424` (Black C64), `#EFEFEF` (White OS), `#AC6DFF` (Strong Lilac), `#928D97` (System Grey).
- Fix the main visual bug where **"Start for free"** and **"See our plans"** were wrapping onto two lines — buttons are now `white-space: nowrap` with trimmed padding so they fit the narrow sidebar.
- Tighten card padding, radius, and typography so the widget doesn't dominate the TOC column; add a subtle lilac glow/shadow.
- Point the primary CTA to `https://scrapegraphai.com/login` instead of `https://dashboard.scrapegraphai.com/`.
- Clean up the logo: remove the inline `style="..."` hack in `script.js` and the conflicting CSS mask rules on `.sgai-cta__brand-logo`.

## Validation

- Cosmetic-only change (CSS + small JS string edits). No ScrapeGraph API endpoint is touched, so the per-URL endpoint validation from the `pre-main-push` skill is not applicable here.

## Test plan

- [x] Open a docs page and confirm the sidebar CTA renders with brand colors in dark mode.
- [x] Toggle to light mode and confirm colors flip correctly (no unreadable text).
- [x] Verify both buttons render on a single line at the current sidebar width.
- [x] Click **Start for free** → lands on `https://scrapegraphai.com/login`.
- [x] Click **See our plans** → lands on `https://scrapegraphai.com/pricing`.
- [x] Confirm the ScrapeGraphAI logo (`/logos/logo-color.svg`) renders correctly (no mask/background artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)