### PR TITLE
docs: remove interactive notebook callouts from cookbook examples

### DIFF
--- a/cookbook/examples/chat-webpage.mdx
+++ b/cookbook/examples/chat-webpage.mdx
@@ -10,11 +10,6 @@ description: 'Build a RAG chatbot for any webpage using ScrapeGraph and LanceDB'
 
 Learn how to build a RAG (Retrieval Augmented Generation) chatbot that can answer questions about any webpage by combining ScrapeGraph's Scrape service (markdown format) with LanceDB vector store and OpenAI.
 
-<Note>
-Try it yourself in our interactive notebooks:
-- [Burr Implementation](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/chat-webpage-simple-rag/scrapegraph_burr_lancedb.ipynb)
-</Note>
-
 ## The Goal
 
 We'll create a chatbot that can:

--- a/cookbook/examples/company-info.mdx
+++ b/cookbook/examples/company-info.mdx
@@ -10,13 +10,6 @@ description: 'Extract structured company data from websites'
 
 Learn how to extract structured company information from websites using ScrapeGraphAI's Extract service. This example demonstrates how to gather company details, contact information, and social media presence.
 
-<Note>
-Try it yourself in our interactive notebooks:
-- [SDK Implementation](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/company-info/scrapegraph_sdk.ipynb)
-- [LangChain Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/company-info/scrapegraph_langchain.ipynb)
-- [LlamaIndex Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/company-info/scrapegraph_llama_index.ipynb)
-</Note>
-
 ## The Goal
 
 We'll extract the following company information:

--- a/cookbook/examples/github-trending.mdx
+++ b/cookbook/examples/github-trending.mdx
@@ -10,13 +10,6 @@ description: 'Monitor trending repositories and developers'
 
 Learn how to extract trending repository information from GitHub using ScrapeGraphAI's Extract service. This example demonstrates how to gather repository statistics, descriptions, and popularity metrics.
 
-<Note>
-Try it yourself in our interactive notebooks:
-- [SDK Implementation](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/github-trending/scrapegraph_sdk.ipynb)
-- [LangChain Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/github-trending/scrapegraph_langchain.ipynb)
-- [LlamaIndex Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/github-trending/scrapegraph_llama_index.ipynb)
-</Note>
-
 ## The Goal
 
 We'll extract the following repository information:

--- a/cookbook/examples/homes.mdx
+++ b/cookbook/examples/homes.mdx
@@ -10,13 +10,6 @@ description: 'How to extract real estate data from Homes.com'
 
 Learn how to extract property listings from Homes.com using ScrapeGraphAI's Extract service. This example demonstrates how to gather detailed property information, pricing, and agent details.
 
-<Note>
-Try it yourself in our interactive notebooks:
-- [SDK Implementation](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/homes-forsale/scrapegraph_sdk.ipynb)
-- [LangChain Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/homes-forsale/scrapegraph_langchain.ipynb)
-- [LlamaIndex Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/homes-forsale/scrapegraph_llama_index.ipynb)
-</Note>
-
 ## The Goal
 
 We'll extract the following property information:

--- a/cookbook/examples/pagination.mdx
+++ b/cookbook/examples/pagination.mdx
@@ -10,13 +10,6 @@ description: 'Walk through paginated listings with the Extract service'
 
 Learn how to walk through paginated listings with ScrapeGraphAI's Extract service. v2 does not ship a built-in `total_pages` parameter — instead, you iterate through each page URL yourself and merge the results. This example demonstrates how to scrape e-commerce products, news articles, or any paginated content across multiple pages.
 
-<Note>
-Try it yourself in our interactive notebooks:
-- [Python SDK (Sync)](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/pagination/sync_example.py)
-- [Python SDK (Async)](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/pagination/async_example.py)
-- [JavaScript SDK](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/pagination/javascript_example.js)
-</Note>
-
 ## The Goal
 
 We'll extract product information from an e-commerce website across multiple pages, including:

--- a/cookbook/examples/research-agent.mdx
+++ b/cookbook/examples/research-agent.mdx
@@ -10,10 +10,6 @@ description: 'Build an AI research agent with ScrapeGraph and Tavily'
 
 Learn how to build a research agent that combines ScrapeGraph's extraction capabilities with Tavily's search API to gather and analyze news articles on specific topics.
 
-<Note>
-Try it yourself in our [News Research Agent Notebook](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/research-agent/scrapegraph_langgraph_tavily.ipynb)
-</Note>
-
 ## The Goal
 
 We'll extract the following information from news articles:

--- a/cookbook/examples/wired.mdx
+++ b/cookbook/examples/wired.mdx
@@ -10,14 +10,6 @@ description: 'How to extract articles from Wired.com'
 
 Learn how to extract article information from Wired.com using ScrapeGraphAI's Extract service. This example demonstrates how to gather article details, categories, and author information.
 
-<Note>
-Try it yourself in our interactive notebooks:
-- [SDK Implementation](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/wired-news/scrapegraph_sdk.ipynb)
-- [LangChain Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/wired-news/scrapegraph_langchain.ipynb)
-- [LangGraph Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/wired-news/scrapegraph_langgraph.ipynb)
-- [LlamaIndex Integration](https://github.com/ScrapeGraphAI/scrapegraph-sdk/blob/main/cookbook/wired-news/scrapegraph_llama_index.ipynb)
-</Note>
-
 ## The Goal
 
 We'll extract the following article information:


### PR DESCRIPTION
## Summary
- Removes the "Try it yourself in our interactive notebooks" `<Note>` blocks from all 7 cookbook example pages (chat-webpage, company-info, github-trending, homes, pagination, research-agent, wired).

## Test plan
- [x] Verify cookbook example pages render cleanly with no lingering notebook callouts
- [x] Confirm no broken anchors/links elsewhere reference the removed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)