### PR TITLE
docs: sync just-scrape CLI docs to v1.1.0 surface

### DIFF
--- a/knowledge-base/cli/ai-agent-skill.mdx
+++ b/knowledge-base/cli/ai-agent-skill.mdx
@@ -61,9 +61,9 @@ The API key is set via the SGAI_API_KEY environment variable.
 Available commands (always use --json flag):
 - `just-scrape extract <url> -p <prompt> --json` — AI structured extraction from a URL
 - `just-scrape search <query> --json` — search the web and extract data from results
-- `just-scrape markdownify <url> --json` — convert a page to markdown
-- `just-scrape crawl <url> -f json -p <prompt> --json` — crawl multiple pages
-- `just-scrape scrape <url> -f html --json` — get raw HTML (or any other format)
+- `just-scrape scrape <url> --json` — fetch a page (markdown default; also html, screenshot, branding, links, images, summary, json)
+- `just-scrape crawl <url> --json` — crawl multiple pages (polls until done)
+- `just-scrape credits --json` / `just-scrape validate --json` — balance and key health
 
 Use --schema to enforce a JSON schema on the output.
 Use --stealth (with -m js if needed) for sites with anti-bot protection.

--- a/knowledge-base/cli/command-examples.mdx
+++ b/knowledge-base/cli/command-examples.mdx
@@ -52,22 +52,6 @@ just-scrape search "Top 5 cloud providers pricing" \
   --schema '{"type":"object","properties":{"providers":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"free_tier":{"type":"string"}}}}}}'
 ```
 
-## markdownify
-
-Convert any webpage to clean markdown. Convenience wrapper around `scrape -f markdown`.
-
-```bash
-# Convert a blog post
-just-scrape markdownify https://blog.example.com/my-article
-
-# Save to file
-just-scrape markdownify https://docs.example.com/api \
-  --json | jq -r '.results.markdown.data[0]' > api-docs.md
-
-# Bypass Cloudflare or anti-bot protections
-just-scrape markdownify https://protected.example.com -m js --stealth
-```
-
 ## scrape
 
 Fetch a page in one or more formats: `markdown`, `html`, `screenshot`, `branding`, `links`, `images`, `summary`, `json`.
@@ -99,19 +83,18 @@ just-scrape scrape https://store.example.com \
 Crawl multiple pages and extract data from each. The CLI starts the crawl and polls until completion.
 
 ```bash
-# Crawl a docs site and collect code examples
+# Crawl a docs site and collect each page as markdown
 just-scrape crawl https://docs.example.com \
-  -f json -p "Extract all code snippets with their language" \
-  --max-pages 20 --max-depth 3
+  -f markdown --max-pages 20 --max-depth 3
 
-# Crawl only blog pages
+# Crawl only blog pages (patterns are a JSON array of regexes)
 just-scrape crawl https://example.com \
   -f markdown \
-  --include-patterns "/blog/*" \
+  --include-patterns '["/blog/.*"]' \
   --max-pages 50
 
-# Raw markdown from all pages (no LLM extraction, cheaper)
-just-scrape crawl https://example.com -f markdown --max-pages 10
+# Multi-format per page (markdown + links)
+just-scrape crawl https://example.com -f markdown,links --max-pages 10
 ```
 
 ## monitor
@@ -120,7 +103,8 @@ Schedule recurring scrape/extract jobs.
 
 ```bash
 # Create a monitor that runs every hour
-just-scrape monitor create https://example.com/pricing \
+just-scrape monitor create \
+  --url https://example.com/pricing \
   --interval "0 * * * *" \
   -f markdown
 
@@ -138,16 +122,29 @@ just-scrape history extract
 
 # Export last 100 crawl jobs as JSON
 just-scrape history crawl --json --page-size 100 \
-  | jq '.requests[] | {id: .request_id, status}'
+  | jq '.[] | {id, status}'
+
+# Fetch one specific request by id
+just-scrape history scrape <request-id> --json
 ```
 
-Services: `scrape`, `extract`, `schema`, `search`, `monitor`, `crawl`.
+Services: `scrape`, `extract`, `search`, `monitor`, `crawl`.
 
 ## credits
 
-Check your remaining credit balance.
+Check your credit balance and per-job quotas.
 
 ```bash
 just-scrape credits
 just-scrape credits --json | jq '.remaining'
+just-scrape credits --json | jq '.jobs.monitor'
+```
+
+## validate
+
+Health-check your API key.
+
+```bash
+just-scrape validate
+just-scrape validate --json | jq -e '.status == "ok"'
 ```

--- a/knowledge-base/cli/getting-started.mdx
+++ b/knowledge-base/cli/getting-started.mdx
@@ -53,10 +53,11 @@ The easiest approach for a new machine is to just run any command — the CLI wi
 | Variable | Description | Default |
 |---|---|---|
 | `SGAI_API_KEY` | ScrapeGraphAI API key | — |
-| `SGAI_API_URL` | Override the API base URL | `https://api.scrapegraphai.com` |
-| `SGAI_TIMEOUT_S` | Request timeout in seconds | `30` |
+| `SGAI_API_URL` | Override the API base URL | `https://api.scrapegraphai.com/api/v2` |
+| `SGAI_TIMEOUT` | Request timeout in seconds | `120` |
+| `SGAI_DEBUG` | Set to `1` to log requests/responses | — |
 
-Legacy variables (`JUST_SCRAPE_API_URL`, `JUST_SCRAPE_TIMEOUT_S`, `JUST_SCRAPE_DEBUG`) are still bridged.
+Legacy variables are still bridged transparently: `JUST_SCRAPE_API_URL` → `SGAI_API_URL`, `JUST_SCRAPE_TIMEOUT_S` / `SGAI_TIMEOUT_S` → `SGAI_TIMEOUT`, `JUST_SCRAPE_DEBUG` → `SGAI_DEBUG`.
 
 ## Verify your setup
 

--- a/knowledge-base/cli/json-mode.mdx
+++ b/knowledge-base/cli/json-mode.mdx
@@ -39,7 +39,7 @@ just-scrape history extract --json | jq '.requests[] | {id: .request_id, status}
 ### Convert a page to markdown and save it
 
 ```bash
-just-scrape markdownify https://docs.example.com/api \
+just-scrape scrape https://docs.example.com/api \
   --json | jq -r '.results.markdown.data[0]' > api-docs.md
 ```
 
@@ -61,7 +61,7 @@ done < urls.txt
 # GitHub Actions example
 - name: Extract changelog
   run: |
-    just-scrape markdownify https://github.com/org/repo/releases \
+    just-scrape scrape https://github.com/org/repo/releases \
       --json | jq -r '.results.markdown.data[0]' > CHANGELOG.md
 ```
 
@@ -70,9 +70,11 @@ done < urls.txt
 The JSON output mirrors the v2 API response for each command. Common shapes:
 
 - **`extract`** — `{ id, json, raw, usage, metadata }`
-- **`scrape` / `markdownify`** — `{ id, results: { markdown: { data: [...] }, ... }, metadata }`
+- **`scrape`** — `{ id, results: { markdown: { data: [...] }, ... }, metadata }`
 - **`search`** — `{ id, results: [...], json, metadata }`
-- **`crawl` start** — `{ id }`; poll with `history crawl <id>` or let the CLI wait for completion
+- **`crawl`** — the CLI polls until the job reaches a terminal state, then prints `{ id, status, finished, total, ... }`
+- **`credits`** — `{ remaining, used, plan, jobs: { crawl: {used, limit}, monitor: {used, limit} } }`
+- **`validate`** — `{ status, uptime }`
 
 For credits:
 
@@ -80,7 +82,11 @@ For credits:
 {
   "remaining": 4820,
   "used": 180,
-  "plan": "Starter"
+  "plan": "Starter",
+  "jobs": {
+    "crawl": { "used": 0, "limit": 50 },
+    "monitor": { "used": 1, "limit": 100 }
+  }
 }
 ```
 

--- a/services/cli.mdx
+++ b/services/cli.mdx
@@ -58,17 +58,18 @@ The CLI needs a ScrapeGraph API key. Four ways to provide it (checked in order):
 | Variable | Description | Default |
 |---|---|---|
 | `SGAI_API_KEY` | ScrapeGraph API key | — |
-| `SGAI_API_URL` | Override API base URL | `https://api.scrapegraphai.com` |
-| `SGAI_TIMEOUT_S` | Request timeout in seconds | `30` |
+| `SGAI_API_URL` | Override API base URL | `https://api.scrapegraphai.com/api/v2` |
+| `SGAI_TIMEOUT` | Request timeout in seconds | `120` |
+| `SGAI_DEBUG` | Set to `1` to log requests/responses | — |
 
-Legacy variables (`JUST_SCRAPE_API_URL`, `JUST_SCRAPE_TIMEOUT_S`, `JUST_SCRAPE_DEBUG`) are still bridged.
+Legacy variables are still bridged transparently: `JUST_SCRAPE_API_URL` → `SGAI_API_URL`, `JUST_SCRAPE_TIMEOUT_S` / `SGAI_TIMEOUT_S` → `SGAI_TIMEOUT`, `JUST_SCRAPE_DEBUG` → `SGAI_DEBUG`.
 
 ## JSON Mode
 
 All commands support `--json` for machine-readable output. Banner, spinners, and interactive prompts are suppressed — only minified JSON on stdout. Saves tokens when piped to AI agents.
 
 ```bash
-just-scrape credits --json | jq '.remainingCredits'
+just-scrape credits --json | jq '.remaining'
 just-scrape extract https://example.com -p "Extract data" --json > result.json
 ```
 
@@ -133,16 +134,6 @@ just-scrape scrape <url> --country <iso>
 | `summary` | AI-generated page summary. |
 | `json` | Structured JSON via `--prompt` (+ optional `--schema`). |
 
-### Markdownify
-
-Convert any webpage to clean markdown (convenience wrapper for `scrape --format markdown`). [Full docs →](/api-reference/scrape)
-
-```bash
-just-scrape markdownify <url>
-just-scrape markdownify <url> -m js --stealth
-just-scrape markdownify <url> --headers <json>
-```
-
 ### Crawl
 
 Crawl multiple pages. The CLI starts the crawl and polls until completion. [Full docs →](/api-reference/crawl)
@@ -159,7 +150,7 @@ just-scrape crawl <url> -m js --stealth
 
 ### Fetch Modes
 
-Use `-m / --mode` on `scrape`, `markdownify`, and `crawl` to choose how pages are fetched. Add `--stealth` to enable anti-bot bypass.
+Use `-m / --mode` on `scrape` and `crawl` to choose how pages are fetched. Add `--stealth` to enable anti-bot bypass.
 
 | Mode | Description |
 |---|---|
@@ -218,7 +209,7 @@ Check your credit balance.
 
 ```bash
 just-scrape credits
-just-scrape credits --json | jq '.remainingCredits'
+just-scrape credits --json | jq '.remaining'
 ```
 
 ## AI Agent Integration

--- a/services/cli/ai-agent-skill.mdx
+++ b/services/cli/ai-agent-skill.mdx
@@ -79,15 +79,15 @@ The API key is set via the SGAI_API_KEY environment variable.
 Available commands (always use --json flag):
 - `just-scrape extract <url> -p <prompt> --json` — AI extraction from a URL
 - `just-scrape search <query> --json` — search the web and extract data
-- `just-scrape markdownify <url> --json` — convert a page to markdown
+- `just-scrape scrape <url> --json` — get page content (markdown is default; also html, screenshot, branding, links, images, summary, json)
 - `just-scrape crawl <url> --json` — crawl multiple pages
-- `just-scrape scrape <url> --json` — get page content (markdown, html, screenshot, branding, links, images, summary, json)
-- `just-scrape credits --json` — check credit balance
+- `just-scrape credits --json` — check credit balance and per-job quotas
+- `just-scrape validate --json` — verify the API key
 
 Use --schema to enforce a JSON schema on the output.
-Use --mode direct+stealth or --mode js+stealth for sites with anti-bot protection.
+Use -m js --stealth for sites with anti-bot protection (fetch modes: auto, fast, js).
 Use -f to pick scrape format(s), e.g. -f markdown,links,images for multi-format.
-Use --location-geo-code and --time-range with search for geo/time filtering.
+Use --country and --time-range with search for geo/time filtering.
 ```
 
 ### Example prompts for Claude Code

--- a/services/cli/commands.mdx
+++ b/services/cli/commands.mdx
@@ -32,16 +32,6 @@ just-scrape search <query> --format <markdown|html>      # result format (defaul
 just-scrape search <query> --headers <json>
 ```
 
-## markdownify
-
-Convert any webpage to clean markdown (convenience wrapper for `scrape --format markdown`). [Full docs →](/api-reference/scrape)
-
-```bash
-just-scrape markdownify <url>
-just-scrape markdownify <url> -m js --stealth            # anti-bot bypass
-just-scrape markdownify <url> --headers <json>
-```
-
 ## scrape
 
 Scrape content from a URL in one or more formats. Supports **8 formats**: `markdown`, `html`, `screenshot`, `branding`, `links`, `images`, `summary`, `json`. [Full docs →](/api-reference/scrape)
@@ -73,6 +63,8 @@ just-scrape crawl <url> --max-pages <n>                  # max pages (default 50
 just-scrape crawl <url> --max-depth <n>                  # crawl depth (default 2)
 just-scrape crawl <url> --max-links-per-page <n>         # max links per page (default 10)
 just-scrape crawl <url> --allow-external                 # allow external domains
+just-scrape crawl <url> --include-patterns '["/blog/.*"]'   # regex allow-list (JSON array)
+just-scrape crawl <url> --exclude-patterns '["/tag/.*"]'    # regex deny-list (JSON array)
 just-scrape crawl <url> -f html                          # page format (default markdown)
 just-scrape crawl <url> -f markdown,links,images         # multi-format (comma-separated)
 just-scrape crawl <url> -m js --stealth                  # anti-bot bypass
@@ -100,24 +92,36 @@ just-scrape monitor activity --id <id> --cursor <cursor>        # paginate with 
 
 ## history
 
-View request history for a service. Interactive by default — arrow keys to navigate, select to view details.
+Browse request history. Interactive by default — arrow keys to navigate, select to view details, "Load more" for pagination.
 
 ```bash
-just-scrape history <service>
+just-scrape history                                      # all services, interactive
+just-scrape history <service>                            # filter by service
+just-scrape history <service> <request-id>               # fetch a specific request
 just-scrape history <service> --page <n>                 # start from page (default 1)
 just-scrape history <service> --page-size <n>            # results per page (max 100)
 just-scrape history <service> --json
 ```
 
-Services: `scrape`, `extract`, `schema`, `search`, `monitor`, `crawl`
+Services: `scrape`, `extract`, `search`, `monitor`, `crawl`
 
 ## credits
 
-Check your credit balance.
+Check your credit balance and per-job quotas.
 
 ```bash
 just-scrape credits
 just-scrape credits --json | jq '.remaining'
+just-scrape credits --json | jq '.jobs.monitor'
+```
+
+## validate
+
+Validate your API key by calling the SDK's health endpoint. Returns `{ "status": "ok", "uptime": ... }` on success.
+
+```bash
+just-scrape validate
+just-scrape validate --json
 ```
 
 ## Global flags

--- a/services/cli/examples.mdx
+++ b/services/cli/examples.mdx
@@ -42,25 +42,15 @@ just-scrape search "React vs Vue comparison" \
   -p "Summarize the key differences"
 ```
 
-## markdownify
-
-```bash
-# Convert a blog post to markdown
-just-scrape markdownify https://blog.example.com/my-article
-
-# Save to a file
-just-scrape markdownify https://docs.example.com/api \
-  --json | jq -r '.markdown' > api-docs.md
-
-# Bypass Cloudflare
-just-scrape markdownify https://protected.example.com -m js --stealth
-```
-
 ## scrape
 
 ```bash
-# Get markdown (default format)
-just-scrape scrape https://example.com
+# Convert a page to markdown (the default format — replaces legacy markdownify)
+just-scrape scrape https://blog.example.com/my-article
+
+# Save markdown to a file
+just-scrape scrape https://docs.example.com/api \
+  --json | jq -r '.results.markdown.data[0]' > api-docs.md
 
 # Get raw HTML with reader-mode extraction
 just-scrape scrape https://blog.example.com -f html --html-mode reader
@@ -97,6 +87,12 @@ just-scrape crawl https://example.com \
 # Allow external links
 just-scrape crawl https://example.com \
   --max-pages 50 --allow-external
+
+# Only crawl blog posts, skip tag archives
+just-scrape crawl https://example.com \
+  --include-patterns '["/blog/.*"]' \
+  --exclude-patterns '["/tag/.*"]' \
+  --max-pages 50
 
 # Anti-bot bypass for protected sites
 just-scrape crawl https://example.com -m js --stealth
@@ -136,8 +132,34 @@ just-scrape history extract
 
 # Export last 100 extract jobs as JSON
 just-scrape history extract --json --page-size 100 \
-  | jq '.[] | {id: .request_id, status}'
+  | jq '.[] | {id, status}'
 
 # Browse crawl history
 just-scrape history crawl --json
+
+# Fetch one specific request by id
+just-scrape history scrape 550e8400-e29b-41d4-a716-446655440000 --json
+```
+
+## credits
+
+```bash
+# Human-readable balance + job quotas
+just-scrape credits
+
+# Just the remaining credit count
+just-scrape credits --json | jq '.remaining'
+
+# Monitor quota usage
+just-scrape credits --json | jq '.jobs.monitor'
+```
+
+## validate
+
+```bash
+# Health-check your API key
+just-scrape validate
+
+# In a script — non-zero exit on failure
+just-scrape validate --json | jq -e '.status == "ok"'
 ```

--- a/services/cli/json-mode.mdx
+++ b/services/cli/json-mode.mdx
@@ -31,7 +31,7 @@ just-scrape extract https://store.example.com \
 ### Extract a specific field with jq
 
 ```bash
-just-scrape credits --json | jq '.remainingCredits'
+just-scrape credits --json | jq '.remaining'
 
 just-scrape history extract --json | jq '.[].status'
 ```
@@ -39,8 +39,8 @@ just-scrape history extract --json | jq '.[].status'
 ### Convert a page to markdown and save it
 
 ```bash
-just-scrape markdownify https://docs.example.com/api \
-  --json | jq -r '.markdown' > api-docs.md
+just-scrape scrape https://docs.example.com/api \
+  --json | jq -r '.results.markdown.data[0]' > api-docs.md
 ```
 
 ### Chain commands in a shell script
@@ -54,22 +54,52 @@ while IFS= read -r url; do
 done < urls.txt
 ```
 
-## Response structure
+## Response shapes
 
-| Field | Description |
-|---|---|
-| `result` | Extracted data or markdown content |
-| `status` | Job status: `completed` or `failed` |
-| `request_id` | Unique ID for the request |
-| `error` | Error message if the request failed |
+Each command prints the SDK response as minified JSON. Common shapes:
 
-Credits response:
+**`scrape`** — returned `data` keyed by requested format:
 
 ```json
 {
-  "remainingCredits": 4820,
-  "totalCredits": 5000
+  "id": "25554af4-8c01-4d9a-890e-d7658d57dc93",
+  "results": {
+    "markdown": { "data": ["# Example Domain\n..."] }
+  },
+  "metadata": { "contentType": "text/html" }
 }
+```
+
+**`extract`** — structured `json` payload plus token usage:
+
+```json
+{
+  "id": "515233e0-b26c-42f3-b4c9-2e993af15546",
+  "raw": null,
+  "json": { "title": "Example Domain" },
+  "usage": { "promptTokens": 359, "completionTokens": 113 },
+  "metadata": {}
+}
+```
+
+**`credits`** — balance and per-job quotas:
+
+```json
+{
+  "remaining": 749575,
+  "used": 712,
+  "plan": "Pro Plan",
+  "jobs": {
+    "crawl": { "used": 0, "limit": 50 },
+    "monitor": { "used": 1, "limit": 100 }
+  }
+}
+```
+
+**`validate`** — health check:
+
+```json
+{ "status": "ok", "uptime": 256372 }
 ```
 
 <Tip>


### PR DESCRIPTION
## Summary

Verified [just-scrape](https://www.npmjs.com/package/just-scrape) v1.1.0 end-to-end against the live API (scrape / extract / credits / validate all OK) and found the docs were still pointing at the v0.x command surface. This PR syncs every live CLI page (`services/cli/*` and `knowledge-base/cli/*`) and the orphan `services/cli.mdx` to the current v1.1.0 surface.

### What was stale

- `markdownify` was removed as a subcommand — it's now just `scrape` (markdown is the default format). The docs still instructed users to call it.
- `validate` was added as a top-level command (health check for the API key) — not documented anywhere.
- Credits response was documented as `{ remainingCredits, totalCredits }` — the real shape is `{ remaining, used, plan, jobs: { crawl, monitor } }`, so every `jq '.remainingCredits'` snippet was broken.
- Env-var table showed `SGAI_TIMEOUT_S` with default 30; the CLI renamed it to `SGAI_TIMEOUT` with default 120 when it migrated to scrapegraph-js v2. `SGAI_API_URL` default was missing the `/api/v2` suffix. `SGAI_DEBUG` wasn't listed.
- `crawl --include-patterns` / `--exclude-patterns` weren't documented, and one example used `crawl -f json -p "..."` (unsupported on v2 — crawl only accepts base formats and has no prompt flag).
- `history`: service was shown as required and included a non-existent `schema` service; the command now accepts an optional service positional plus an optional `<request-id>`.
- `monitor create` example used a positional URL; the CLI expects `--url`.
- Agent-skill snippet referenced `--location-geo-code` which doesn't exist — the flag is `--country`.

### Scope

Files touched (all doc-only):

- `services/cli/{commands,examples,json-mode,ai-agent-skill}.mdx`
- `knowledge-base/cli/{getting-started,command-examples,json-mode,ai-agent-skill}.mdx`
- `services/cli.mdx` (orphan page, not in docs.json nav, but cleaned up defensively)

## Test plan

- [x] `npx just-scrape@latest --help` — confirmed command list matches docs
- [x] `just-scrape validate --json` → `{"status":"ok","uptime":...}`
- [x] `just-scrape credits --json` → `{remaining, used, plan, jobs: {crawl, monitor}}`
- [x] `just-scrape scrape https://example.com --json` → real data, shape matches new doc
- [x] `just-scrape extract https://example.com -p "..." --json` → real data
- [x] `just-scrape markdownify ...` → errors with `Unknown command markdownify` (confirms removal)
- [x] Preview the rendered docs pages in Mintlify before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)