### PR TITLE
docs: add History endpoint and crawl page-content recipe

### DIFF
--- a/api-reference/endpoint/crawl/get-status.mdx
+++ b/api-reference/endpoint/crawl/get-status.mdx
@@ -50,13 +50,26 @@ curl -X GET https://v2-api.scrapegraphai.com/api/crawl/79694e03-f2ea-43f2-93cc-7
 | `status` | `"running"`, `"completed"`, `"failed"`, or `"stopped"`. |
 | `total` / `finished` | Progress counters. |
 | `pages[]` | Per-page results, ordered by crawl time. |
-| `pages[].scrapeRefId` | UUID of the underlying Scrape call — use it to fetch the full formatted content. |
+| `pages[].scrapeRefId` | UUID of the underlying Scrape call — pass to `GET /api/history/:id` to fetch the formatted content (markdown, HTML, JSON, screenshot, etc.). |
 
 <Note>
 Poll at a reasonable cadence (every 1–5 seconds) until `status` is `"completed"`, `"failed"`, or `"stopped"`. Or use [Monitor](/services/monitor) with a webhook to avoid polling entirely.
 </Note>
 
+## Fetching page content
+
+The crawl response intentionally returns lightweight metadata (`url`, `depth`, `scrapeRefId`, etc.) rather than embedding every page's full body. Use [`GET /api/history/:id`](/api-reference/endpoint/history) with each `scrapeRefId` to fetch the formatted content the underlying scrape produced:
+
+```bash
+# Pick a scrapeRefId from the pages[] array above
+curl -X GET https://v2-api.scrapegraphai.com/api/history/9701fc04-23de-4684-a48f-7e8fa287550b \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+```
+
+The response is a `HistoryEntry` with the full `result` payload, e.g. `result.results.markdown.data[0]` for markdown. See the [History endpoint reference](/api-reference/endpoint/history) for the entry shape and a complete crawl-to-content example.
+
 ## Related
 
 - Start a job: [`POST /api/crawl`](/api-reference/endpoint/crawl/start)
 - Stop / resume / delete: [Manage crawl jobs](/api-reference/endpoint/crawl/manage)
+- Fetch each page's content: [History](/api-reference/endpoint/history)

--- a/api-reference/endpoint/history.mdx
+++ b/api-reference/endpoint/history.mdx
@@ -1,0 +1,192 @@
+---
+title: 'History'
+description: 'Look up past requests by ID, or list recent requests with optional filters.'
+---
+
+```http
+GET https://v2-api.scrapegraphai.com/api/history
+GET https://v2-api.scrapegraphai.com/api/history/:id
+```
+
+History stores every API call your account makes (scrape, extract, search, monitor ticks, crawl jobs, schema generations) and lets you fetch them back later by ID. The most common use case is **retrieving the content of a crawled page** — `GET /api/crawl/:id` returns each page's `scrapeRefId`, and you call `GET /api/history/:scrapeRefId` to get the formatted content (markdown, HTML, JSON extraction, screenshots, etc.) that the underlying scrape produced.
+
+## List history
+
+```http
+GET https://v2-api.scrapegraphai.com/api/history
+```
+
+Returns a paginated list of recent entries, newest first.
+
+### Query parameters
+
+<ParamField query="page" type="integer" default="1">
+  Page number to fetch (1-indexed).
+</ParamField>
+
+<ParamField query="limit" type="integer" default="20">
+  Entries per page.
+</ParamField>
+
+<ParamField query="service" type="string">
+  Filter by service. One of `"scrape"`, `"extract"`, `"search"`, `"monitor"`, `"crawl"`, `"schema"`.
+</ParamField>
+
+### Example request
+
+```bash
+curl -X GET "https://v2-api.scrapegraphai.com/api/history?service=scrape&limit=5" \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+```
+
+### Example response
+
+```json
+{
+  "data": [
+    {
+      "id": "9701fc04-23de-4684-a48f-7e8fa287550b",
+      "userId": "4406e370-2405-4927-b7b3-b85c0a769b63",
+      "service": "scrape",
+      "status": "completed",
+      "params": {
+        "url": "https://scrapegraphai.com/",
+        "formats": [{ "mode": "normal", "type": "markdown" }]
+      },
+      "result": {
+        "results": { "markdown": { "data": ["# ScrapeGraphAI..."] } },
+        "metadata": { "contentType": "text/html" }
+      },
+      "error": null,
+      "elapsedMs": 533,
+      "requestParentId": "06aa21dd-9a3a-417b-b2dd-0cd0943b7ded",
+      "createdAt": "2026-04-28T09:00:02.907Z"
+    }
+  ],
+  "pagination": { "page": 1, "limit": 5, "total": 178 }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `data[]` | Ordered list of history entries (newest first). See [Entry shape](#entry-shape). |
+| `pagination.page` / `.limit` | Echo of the request's `page` and `limit`. |
+| `pagination.total` | Total entry count matching the filter (across all pages). |
+
+## Get one entry
+
+```http
+GET https://v2-api.scrapegraphai.com/api/history/:id
+```
+
+Returns the full record for a single request — including the full `result` payload (markdown, HTML, JSON extraction, screenshots, etc.).
+
+### Path parameters
+
+<ParamField path="id" type="string" required>
+  The UUID of a request. This is the same UUID returned by the originating endpoint:
+
+  - From `POST /api/scrape` → top-level `id`
+  - From `POST /api/extract` → top-level `id`
+  - From `POST /api/search` → top-level `id`
+  - From `GET /api/crawl/:id` → each `pages[].scrapeRefId`
+  - From `GET /api/monitor/:cronId/activity` → each `ticks[].id`
+</ParamField>
+
+### Example request
+
+```bash
+curl -X GET https://v2-api.scrapegraphai.com/api/history/9701fc04-23de-4684-a48f-7e8fa287550b \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+```
+
+### Example response
+
+```json
+{
+  "id": "9701fc04-23de-4684-a48f-7e8fa287550b",
+  "userId": "4406e370-2405-4927-b7b3-b85c0a769b63",
+  "service": "scrape",
+  "status": "completed",
+  "params": {
+    "url": "https://scrapegraphai.com/",
+    "formats": [{ "mode": "normal", "type": "markdown" }]
+  },
+  "result": {
+    "results": {
+      "markdown": {
+        "data": ["# ScrapeGraphAI\n\nThe scraper for the AI Era..."]
+      }
+    },
+    "metadata": { "contentType": "text/html" }
+  },
+  "error": null,
+  "elapsedMs": 533,
+  "requestParentId": "06aa21dd-9a3a-417b-b2dd-0cd0943b7ded",
+  "createdAt": "2026-04-28T09:00:02.907Z"
+}
+```
+
+## Entry shape
+
+Every entry — both in `GET /history` and `GET /history/:id` — has the same shape:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Entry UUID. Same UUID as the originating endpoint returned. |
+| `userId` | The account that issued the request. |
+| `service` | `"scrape"` \| `"extract"` \| `"search"` \| `"monitor"` \| `"crawl"` \| `"schema"`. |
+| `status` | Lifecycle: `"running"` \| `"completed"` \| `"failed"`. |
+| `params` | The request body that produced this entry (URL, prompt, formats, etc.). |
+| `result` | The full response payload, shaped per the originating endpoint. `null` while running, populated on completion. |
+| `error` | Error object if `status === "failed"`, otherwise `null`. |
+| `elapsedMs` | How long the request took, in milliseconds. |
+| `requestParentId` | If this entry was created as a child of another (e.g. a scrape run by a crawl), the parent's UUID. `null` for top-level requests. |
+| `createdAt` | ISO-8601 timestamp. |
+
+## Fetching crawled page content
+
+The canonical pattern: start a crawl, poll until completed, then for each page fetch its scrape result.
+
+```bash
+# 1. Start the crawl
+curl -X POST https://v2-api.scrapegraphai.com/api/crawl \
+  -H "SGAI-APIKEY: $SGAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "url": "https://example.com", "formats": [{ "type": "markdown" }], "maxPages": 5 }'
+# → { "id": "crawl-uuid", "status": "running", ... }
+
+# 2. Poll status until completed
+curl -X GET https://v2-api.scrapegraphai.com/api/crawl/crawl-uuid \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+# → { "status": "completed", "pages": [{ "url": "...", "scrapeRefId": "page-uuid", ... }] }
+
+# 3. Fetch each page's content via history
+curl -X GET https://v2-api.scrapegraphai.com/api/history/page-uuid \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+# → { "service": "scrape", "result": { "results": { "markdown": { "data": ["# ..."] } } }, ... }
+```
+
+The `requestParentId` on each child scrape entry equals the parent crawl's `id`, so you can also list every page produced by a single crawl with:
+
+```bash
+curl -X GET "https://v2-api.scrapegraphai.com/api/history?service=scrape&limit=100" \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+# Then filter client-side by `requestParentId === crawl-uuid`.
+```
+
+## Errors
+
+| HTTP | `error.type` | When |
+|------|--------------|------|
+| `400` | `validation` | Malformed `id` (must be a UUID), or invalid `service` filter value. |
+| `404` | `not_found` | The `id` is well-formed but no matching entry exists for this account. |
+| `403` | `auth_invalid_key` | The API key is invalid or revoked. |
+
+See [Error handling](/api-reference/errors) for the full envelope.
+
+## Related
+
+- Crawl jobs that produce `scrapeRefId`s: [Get crawl status](/api-reference/endpoint/crawl/get-status)
+- Originating endpoints whose `id` you can pass to `GET /history/:id`: [Scrape](/api-reference/endpoint/scrape), [Extract](/api-reference/endpoint/extract), [Search](/api-reference/endpoint/search)
+- SDK wrappers: `sgai.history.list()` and `sgai.history.get(id)` — see [JavaScript SDK](/sdks/javascript) and [Python SDK](/sdks/python)

--- a/api-reference/errors.mdx
+++ b/api-reference/errors.mdx
@@ -84,7 +84,20 @@ Returned when the request body fails schema validation. The `details` array name
 }
 ```
 
-Common `code` values: `invalid_format`, `invalid_type`, `too_small`, `too_big`, `custom`.
+Common `code` values: `invalid_format`, `invalid_type`, `too_small`, `too_big`, `invalid_value`, `custom`.
+
+## Not found (404)
+
+```json
+{
+  "error": {
+    "type": "not_found",
+    "message": "Request not found"
+  }
+}
+```
+
+The resource ID is well-formed but does not exist for this account. Returned by lookup endpoints such as `GET /api/history/:id`, `GET /api/crawl/:id`, and `GET /api/monitor/:cronId` when the UUID does not correspond to a record on your account.
 
 ## Quota and rate limit errors
 
@@ -132,6 +145,7 @@ Transient — retry with exponential backoff. If errors persist, check the [stat
 | Error | Retryable? | Recommended action |
 |-------|------------|--------------------|
 | `validation` (400) | No | Fix the request body. |
+| `not_found` (404) | No | Verify the ID is correct and belongs to this account. |
 | `auth_missing_key` / `auth_invalid_key` (401/403) | No | Fix the header or rotate the key. |
 | `insufficient_credits` (402) | No | Top up credits. |
 | `rate_limited` (429) | Yes | Exponential backoff, honor any `Retry-After` header. |

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -12,6 +12,7 @@ The ScrapeGraphAI v2 API exposes five core services behind a single host. All en
 - **Search** — web search with page content returned inline and optional AI extraction across results.
 - **Crawl** — async multi-page traversal with URL patterns, depth limits, and per-page formats.
 - **Monitor** — cron-scheduled watches with change detection and optional webhooks.
+- **History** — look up past requests by ID, including the formatted content of crawled pages via each `scrapeRefId`.
 
 Prefer using an SDK? See the [Python SDK](/sdks/python) or [JavaScript SDK](/sdks/javascript) — both wrap this same API.
 
@@ -63,6 +64,9 @@ Keep your API key secret. Never ship it in client-side code — load it from an 
   <Card title="Monitor · manage" icon="sliders" href="/api-reference/endpoint/monitor/manage">
     List, pause, resume, update, delete monitors; fetch activity.
   </Card>
+  <Card title="History" icon="clock-rotate-left" href="/api-reference/endpoint/history">
+    `GET /api/history[/:id]` — list past requests or fetch a single result by ID (including content for crawled pages).
+  </Card>
   <Card title="Credits" icon="coins" href="/api-reference/endpoint/credits">
     `GET /api/credits` — remaining balance and job quotas.
   </Card>
@@ -75,8 +79,9 @@ Keep your API key secret. Never ship it in client-side code — load it from an 
 | `200` | Success |
 | `400` | Validation error — the request body didn't pass schema checks. |
 | `401` | Missing `SGAI-APIKEY` header. |
-| `403` | Invalid or deprecated API key. |
 | `402` | Insufficient credits. |
+| `403` | Invalid or deprecated API key. |
+| `404` | Not found — the resource ID does not exist for this account. |
 | `429` | Rate limit exceeded. |
 | `500` | Server error. |
 

--- a/docs.json
+++ b/docs.json
@@ -52,6 +52,7 @@
                   "services/search",
                   "services/crawl",
                   "services/monitor",
+                  "services/history",
                   {
                     "group": "Additional Parameters",
                     "pages": [
@@ -237,6 +238,12 @@
                 "pages": [
                   "api-reference/endpoint/monitor/create",
                   "api-reference/endpoint/monitor/manage"
+                ]
+              },
+              {
+                "group": "History",
+                "pages": [
+                  "api-reference/endpoint/history"
                 ]
               },
               {

--- a/services/crawl.mdx
+++ b/services/crawl.mdx
@@ -156,6 +156,41 @@ Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
 ```
 </Accordion>
 
+## Fetching page content
+
+The crawl response returns each page as lightweight metadata (`url`, `depth`, `scrapeRefId`, …) — not the full body. Use the [History](/services/history) service with each `scrapeRefId` to pull the formatted content the underlying scrape produced.
+
+<CodeGroup>
+
+```python Python
+# After the crawl completes, fetch the markdown for each page
+for page in status.data.pages:
+    if page.status != "completed":
+        continue
+    entry = sgai.history.get(page.scrape_ref_id)
+    md = entry.data.result.results.get("markdown", {}).get("data", [None])[0]
+    print(page.url, "->", md[:80] if md else "(empty)")
+```
+
+```javascript JavaScript
+for (const page of status.data.pages) {
+  if (page.status !== "completed") continue;
+  const entry = await sgai.history.get(page.scrapeRefId);
+  const md = entry.data?.result?.results?.markdown?.data?.[0];
+  console.log(page.url, "->", md?.slice(0, 80) ?? "(empty)");
+}
+```
+
+```bash cURL
+# Pick any scrapeRefId from the pages[] array of the crawl status response
+curl -X GET https://v2-api.scrapegraphai.com/api/history/<scrapeRefId> \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+```
+
+</CodeGroup>
+
+See the [History service](/services/history) for the full entry shape and the `requestParentId` linkage that ties each child scrape back to its parent crawl.
+
 ## Managing Crawl Jobs
 
 ```python

--- a/services/history.mdx
+++ b/services/history.mdx
@@ -1,0 +1,230 @@
+---
+title: 'History'
+description: 'Look up past requests and fetch the full results — including content from crawled pages.'
+icon: 'clock-rotate-left'
+---
+
+## Overview
+
+History keeps a record of every API call your account makes (`scrape`, `extract`, `search`, monitor ticks, crawl jobs, schema generations) and lets you fetch the full result back later by ID. The most common use case is **retrieving the formatted content of a crawled page** — the [Crawl](/services/crawl) service returns each page as a `scrapeRefId`, and History is what you call with that ID to get the markdown, HTML, JSON extraction, or screenshot the underlying scrape produced.
+
+## Getting Started
+
+### Quick Start
+
+<CodeGroup>
+
+```python Python
+from scrapegraph_py import ScrapeGraphAI
+
+# reads SGAI_API_KEY from env, or pass explicitly: ScrapeGraphAI(api_key="...")
+sgai = ScrapeGraphAI()
+
+# List recent scrape calls
+page = sgai.history.list(service="scrape", limit=5)
+for entry in page.data.data:
+    print(entry.id, entry.service, entry.status, entry.elapsed_ms)
+
+# Fetch one entry, including the full result
+one = sgai.history.get("9701fc04-23de-4684-a48f-7e8fa287550b")
+if one.status == "success":
+    print(one.data.result)
+```
+
+```javascript JavaScript
+import { ScrapeGraphAI } from "scrapegraph-js";
+
+const sgai = ScrapeGraphAI();
+
+// List recent scrape calls
+const list = await sgai.history.list({ service: "scrape", limit: 5 });
+if (list.status === "success") {
+  for (const entry of list.data?.data ?? []) {
+    console.log(entry.id, entry.service, entry.status);
+  }
+}
+
+// Fetch one entry, including the full result
+const one = await sgai.history.get("9701fc04-23de-4684-a48f-7e8fa287550b");
+if (one.status === "success") {
+  console.log(one.data?.result);
+}
+```
+
+```bash cURL
+# List
+curl -X GET "https://v2-api.scrapegraphai.com/api/history?service=scrape&limit=5" \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+
+# Get one
+curl -X GET https://v2-api.scrapegraphai.com/api/history/9701fc04-23de-4684-a48f-7e8fa287550b \
+  -H "SGAI-APIKEY: $SGAI_API_KEY"
+```
+
+</CodeGroup>
+
+#### Parameters
+
+**List** (`GET /api/history`)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page` | integer | No | Page number (1-indexed). Default: `1`. |
+| `limit` | integer | No | Entries per page. Default: `20`. |
+| `service` | string | No | Filter by service: `scrape`, `extract`, `search`, `monitor`, `crawl`, `schema`. |
+
+**Get** (`GET /api/history/:id`)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | UUID of the request. Same UUID returned by the originating endpoint, or any `scrapeRefId` from a crawl. |
+
+<Note>
+Get your API key from the [dashboard](https://scrapegraphai.com/dashboard).
+</Note>
+
+## Fetching crawled page content
+
+This is the canonical pattern: start a crawl, poll until done, then call History for each page.
+
+<CodeGroup>
+
+```python Python
+import time
+from scrapegraph_py import ScrapeGraphAI, MarkdownFormatConfig
+
+sgai = ScrapeGraphAI()
+
+start = sgai.crawl.start(
+    "https://scrapegraphai.com/",
+    formats=[MarkdownFormatConfig()],
+    max_pages=5,
+    max_depth=2,
+)
+crawl_id = start.data.id
+
+while True:
+    time.sleep(2)
+    status = sgai.crawl.get(crawl_id)
+    if status.data.status in ("completed", "failed"):
+        break
+
+# Pull the formatted content for every completed page
+for page in status.data.pages:
+    if page.status != "completed":
+        continue
+    entry = sgai.history.get(page.scrape_ref_id)
+    md = entry.data.result.results.get("markdown", {}).get("data", [None])[0]
+    print(page.url, "->", md[:80] if md else "(empty)")
+```
+
+```javascript JavaScript
+import { ScrapeGraphAI } from "scrapegraph-js";
+
+const sgai = ScrapeGraphAI();
+
+const start = await sgai.crawl.start({
+  url: "https://scrapegraphai.com/",
+  formats: [{ type: "markdown" }],
+  maxPages: 5,
+  maxDepth: 2,
+});
+const crawlId = start.data.id;
+
+let status = start.data.status;
+let pages = [];
+while (status === "running") {
+  await new Promise((r) => setTimeout(r, 2000));
+  const res = await sgai.crawl.get(crawlId);
+  status = res.data.status;
+  pages = res.data.pages;
+}
+
+for (const page of pages) {
+  if (page.status !== "completed") continue;
+  const entry = await sgai.history.get(page.scrapeRefId);
+  const md = entry.data?.result?.results?.markdown?.data?.[0];
+  console.log(page.url, "->", md?.slice(0, 80) ?? "(empty)");
+}
+```
+
+</CodeGroup>
+
+### Linking children to a parent crawl
+
+Every child scrape entry produced by a crawl has `requestParentId` set to the parent crawl's `id`. So you can also list all pages from a single crawl by filtering on the client:
+
+```python
+page = sgai.history.list(service="scrape", limit=100)
+children = [e for e in page.data.data if e.request_parent_id == crawl_id]
+```
+
+## Entry shape
+
+| Field | Description |
+|-------|-------------|
+| `id` | Entry UUID — same UUID the originating endpoint returned. |
+| `service` | `scrape` \| `extract` \| `search` \| `monitor` \| `crawl` \| `schema`. |
+| `status` | `running` \| `completed` \| `failed`. |
+| `params` | The request body that produced this entry. |
+| `result` | The full response payload (shaped per the originating service). `null` while running. |
+| `error` | Error object if `status === "failed"`, otherwise `null`. |
+| `elapsedMs` | How long the request took, in milliseconds. |
+| `requestParentId` | Parent UUID if this entry was created by another request (e.g. a scrape from a crawl). `null` for top-level. |
+| `createdAt` | ISO-8601 timestamp. |
+
+## Async Support (Python)
+
+```python
+import asyncio
+from scrapegraph_py import AsyncScrapeGraphAI
+
+async def main():
+    async with AsyncScrapeGraphAI() as sgai:
+        page = await sgai.history.list(service="scrape", limit=10)
+        if page.status == "success":
+            for entry in page.data.data:
+                print(entry.id, entry.created_at)
+
+asyncio.run(main())
+```
+
+## Key Features
+
+<CardGroup cols={2}>
+  <Card title="Crawl Page Content" icon="spider">
+    Resolve `scrapeRefId`s from crawl results to fetch each page's formatted content.
+  </Card>
+  <Card title="Replay Past Requests" icon="clock-rotate-left">
+    Fetch the full result of any past call without re-running it (no extra credits).
+  </Card>
+  <Card title="Service Filtering" icon="filter">
+    Narrow by `scrape`, `extract`, `search`, `monitor`, `crawl`, or `schema`.
+  </Card>
+  <Card title="Parent Linking" icon="link">
+    `requestParentId` ties child requests back to the crawl or workflow that spawned them.
+  </Card>
+</CardGroup>
+
+## Integration Options
+
+### Official SDKs
+- [Python SDK](/sdks/python)
+- [JavaScript SDK](/sdks/javascript) (`scrapegraph-js` ≥ 2.1.0, Node ≥ 22)
+
+## Support & Resources
+
+<CardGroup cols={2}>
+  <Card title="API Reference" icon="code" href="/api-reference/endpoint/history">
+    Detailed endpoint documentation
+  </Card>
+  <Card title="Crawl Service" icon="spider" href="/services/crawl">
+    The most common source of `scrapeRefId`s
+  </Card>
+  <Card title="Community" icon="discord" href="https://discord.gg/uJN7TYcpNa">
+    Join our Discord community
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/ScrapeGraphAI">
+    Check out our open-source projects
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Documents `GET /api/history` (list with `page` / `limit` / `service` filters) and `GET /api/history/:id` (single entry with full `result` payload), under a new `api-reference/endpoint/history.mdx`.
- Adds a `services/history.mdx` service page (Home tab) with Python / JS / cURL examples, including the canonical "fetch crawled page content" pattern.
- Wires up the previously-dangling `scrapeRefId` reference: `crawl/get-status.mdx` and `services/crawl.mdx` now show how to pass each `pages[].scrapeRefId` to `GET /api/history/:id` to retrieve the formatted page content (markdown, HTML, JSON, screenshot, etc.).
- Adds the `404 not_found` error type to `api-reference/errors.mdx` (it's returned by lookup endpoints when the UUID does not exist for the account, but it was missing from the docs). Adds `invalid_value` to the common validation codes list.
- Updates `api-reference/introduction.mdx` (service overview list, endpoint card group, HTTP status code table now includes 404).
- Updates `docs.json` to add `services/history` to the Services group and a new `History` group in the API Reference tab.

## Why

Two real doc gaps surfaced while integrating v2 into the n8n community node:

1. The crawl response advertises `pages[].scrapeRefId` as ""use it to fetch the full formatted content"" but no public docs explained which endpoint consumes it. The `GET /api/history/:id` endpoint is fully implemented and exposed by both SDKs (`sgai.history.get(id)`), it just wasn't documented.
2. `404 not_found` is returned live (verified against `https://v2-api.scrapegraphai.com/api/history/<unknown-uuid>`) but `errors.mdx` only listed 400 / 401 / 402 / 403 / 429 / 5xx.

## Test plan

- [ ] Mintlify dev preview renders `services/history` and `api-reference/endpoint/history` without nav breakage
- [ ] Search/sidebar surfaces ""History"" under both Services and API Reference
- [ ] Cross-links from `services/crawl` and `api-reference/endpoint/crawl/get-status` resolve to the new history pages
- [ ] `docs.json` validates as JSON (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)