### PR TITLE
docs: Crawl allowExternal + contentTypes, defaults, search dropdown

### DIFF
--- a/integrations/make.mdx
+++ b/integrations/make.mdx
@@ -150,7 +150,7 @@ Run a web search and get page content returned inline — optionally with AI ext
 | Format | Content format for each result |
 | Extraction Prompt | Optional AI extraction applied to each page |
 | Output Schema (JSON) | Optional schema — requires Extraction Prompt |
-| Country Code | 2-letter country code for localised results |
+| Country Code | Curated dropdown of 51 country codes for localised results (US, UK, Germany, Japan, India, …) |
 | Fetch Config | Optional fetch options — see [Fetch Config](#fetch-config) |
 
 ---
@@ -168,10 +168,12 @@ Start a multi-page crawl from an entry URL. The module polls internally and retu
 | URL | Entry point for the crawl |
 | Format | Output format per page (markdown / HTML / JSON / screenshot / links / images / summary / branding) |
 | HTML Mode / JSON Prompt / Screenshot dimensions | Format-specific sub-fields, surface based on the chosen Format |
-| Max Pages | Cap on total pages crawled (1–1000) |
-| Max Depth | How many link levels deep to traverse |
-| Max Links Per Page | Maximum links to follow per page |
+| Max Pages | Cap on total pages crawled (1–1000). Default `50`. |
+| Max Depth | How many link levels deep to traverse. Default `2`. |
+| Max Links Per Page | Maximum links to follow per page. Default `10`. |
+| Allow External Links | Whether to follow links to other domains. Off by default — same-origin only. |
 | Include / Exclude Patterns | URL glob patterns, e.g. `/blog/*` |
+| Content Types | Optional MIME-type filter (HTML, PDF, Word, Excel, …). Leave empty for all. |
 | Fetch Config | Optional fetch options — see [Fetch Config](#fetch-config) |
 
 **Output:**

--- a/integrations/make.mdx
+++ b/integrations/make.mdx
@@ -150,7 +150,7 @@ Run a web search and get page content returned inline — optionally with AI ext
 | Format | Content format for each result |
 | Extraction Prompt | Optional AI extraction applied to each page |
 | Output Schema (JSON) | Optional schema — requires Extraction Prompt |
-| Country Code | Curated dropdown of 51 country codes for localised results (US, UK, Germany, Japan, India, …) |
+| Country Code | Curated dropdown of 52 country codes for localised results (US, UK, Germany, Japan, India, …) |
 | Fetch Config | Optional fetch options — see [Fetch Config](#fetch-config) |
 
 ---

--- a/integrations/n8n.mdx
+++ b/integrations/n8n.mdx
@@ -55,7 +55,7 @@ Get your API key from the [ScrapeGraphAI dashboard](https://scrapegraphai.com/da
 | **Scrape** | `scrape` | Fetch a page in markdown, HTML, JSON (AI-extracted), screenshot, links, summary, branding, or any combination |
 | **Extract** | `extract` | Run a natural-language prompt over a URL, raw HTML, or markdown — optional JSON schema |
 | **Search** | `search` | AI web search with inline content; optional rollup prompt across results |
-| **Crawl** | `start`, `getStatus`, `stop`, `resume`, `delete` | Async multi-page crawls with patterns, depth, and per-page formats |
+| **Crawl** | `start`, `getStatus`, `stop`, `resume`, `delete` | Async multi-page crawls with patterns, depth, per-page formats, MIME-type filters, and an external-link toggle |
 | **Monitor** | `create`, `list`, `get`, `update`, `pause`, `resume`, `delete`, `activity` | Cron-scheduled fetches with diff detection and webhooks |
 | **History** | `get`, `list` | Look up past results by `scrapeRefId` — used to fetch full content for crawled pages |
 | **Credit** | `get` | Check remaining credits and plan |

--- a/services/crawl.mdx
+++ b/services/crawl.mdx
@@ -110,11 +110,13 @@ curl -X GET https://v2-api.scrapegraphai.com/api/crawl/:id \
 |-----------|------|----------|-------------|
 | `url` | string | Yes | Starting URL to crawl. |
 | `formats` | array | No | Output formats per page (see [Scrape formats](/services/scrape#output-formats)). |
-| `maxPages` / `max_pages` | int | No | Maximum number of pages to crawl. |
-| `maxDepth` / `max_depth` | int | No | How many levels deep to follow links. |
-| `maxLinksPerPage` / `max_links_per_page` | int | No | Cap on links expanded per page. |
+| `maxPages` / `max_pages` | int | No | Maximum number of pages to crawl. Default `50`, max `1000`. |
+| `maxDepth` / `max_depth` | int | No | How many levels deep to follow links. Default `2`. |
+| `maxLinksPerPage` / `max_links_per_page` | int | No | Cap on links expanded per page. Default `10`. |
+| `allowExternal` / `allow_external` | bool | No | Whether to follow links to other domains. Default `false` (same-origin only). |
 | `includePatterns` / `include_patterns` | array | No | URL patterns to include (e.g. `["/blog/*"]`). |
 | `excludePatterns` / `exclude_patterns` | array | No | URL patterns to exclude (e.g. `["/admin/*"]`). |
+| `contentTypes` / `content_types` | array | No | Limit crawled pages to these MIME types, e.g. `["text/html", "application/pdf"]`. |
 | `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>

--- a/services/search.mdx
+++ b/services/search.mdx
@@ -83,6 +83,7 @@ curl -X POST https://v2-api.scrapegraphai.com/api/search \
 | `prompt` | string | No | Prompt used for AI extraction across the fetched results. |
 | `schema` | object | No | JSON schema for structured output (requires `prompt`). In Python you can pass a Pydantic model via `MyModel.model_json_schema()`. |
 | `format` | string | No | Output format for page content: `"markdown"` (default) or `"html"`. |
+| `mode` | string | No | HTML processing mode: `"normal"`, `"reader"`, or `"prune"`. Default: `"prune"` (different from Scrape/Extract, which default to `"normal"`). |
 | `timeRange` / `time_range` | string | No | Recency filter: `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"`. |
 | `locationGeoCode` / `location_geo_code` | string | No | Two-letter ISO country code for localized results. Curated set: `ar`, `at`, `au`, `ae`, `be`, `br`, `ca`, `ch`, `cl`, `cn`, `co`, `cz`, `de`, `dk`, `eg`, `es`, `fi`, `fr`, `gb`, `gr`, `hk`, `hu`, `id`, `ie`, `il`, `in`, `it`, `jp`, `kr`, `mx`, `my`, `ng`, `nl`, `no`, `nz`, `pe`, `ph`, `pk`, `pl`, `pt`, `ro`, `ru`, `sa`, `se`, `sg`, `th`, `tr`, `tw`, `ua`, `us`, `vn`, `za`. |
 | `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |

--- a/services/search.mdx
+++ b/services/search.mdx
@@ -84,7 +84,7 @@ curl -X POST https://v2-api.scrapegraphai.com/api/search \
 | `schema` | object | No | JSON schema for structured output (requires `prompt`). In Python you can pass a Pydantic model via `MyModel.model_json_schema()`. |
 | `format` | string | No | Output format for page content: `"markdown"` (default) or `"html"`. |
 | `timeRange` / `time_range` | string | No | Recency filter: `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"`. |
-| `locationGeoCode` / `location_geo_code` | string | No | Two-letter ISO country code for localized results (e.g. `"us"`, `"it"`). |
+| `locationGeoCode` / `location_geo_code` | string | No | Two-letter ISO country code for localized results. Curated set: `ar`, `at`, `au`, `ae`, `be`, `br`, `ca`, `ch`, `cl`, `cn`, `co`, `cz`, `de`, `dk`, `eg`, `es`, `fi`, `fr`, `gb`, `gr`, `hk`, `hu`, `id`, `ie`, `il`, `in`, `it`, `jp`, `kr`, `mx`, `my`, `ng`, `nl`, `no`, `nz`, `pe`, `ph`, `pk`, `pl`, `pt`, `ro`, `ru`, `sa`, `se`, `sg`, `th`, `tr`, `tw`, `ua`, `us`, `vn`, `za`. |
 | `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>

--- a/services/search.mdx
+++ b/services/search.mdx
@@ -85,7 +85,7 @@ curl -X POST https://v2-api.scrapegraphai.com/api/search \
 | `format` | string | No | Output format for page content: `"markdown"` (default) or `"html"`. |
 | `mode` | string | No | HTML processing mode: `"normal"`, `"reader"`, or `"prune"`. Default: `"prune"` (different from Scrape/Extract, which default to `"normal"`). |
 | `timeRange` / `time_range` | string | No | Recency filter: `"past_hour"`, `"past_24_hours"`, `"past_week"`, `"past_month"`, `"past_year"`. |
-| `locationGeoCode` / `location_geo_code` | string | No | Two-letter ISO country code for localized results. Curated set: `ar`, `at`, `au`, `ae`, `be`, `br`, `ca`, `ch`, `cl`, `cn`, `co`, `cz`, `de`, `dk`, `eg`, `es`, `fi`, `fr`, `gb`, `gr`, `hk`, `hu`, `id`, `ie`, `il`, `in`, `it`, `jp`, `kr`, `mx`, `my`, `ng`, `nl`, `no`, `nz`, `pe`, `ph`, `pk`, `pl`, `pt`, `ro`, `ru`, `sa`, `se`, `sg`, `th`, `tr`, `tw`, `ua`, `us`, `vn`, `za`. |
+| `locationGeoCode` / `location_geo_code` | string | No | Two-letter ISO country code for localized results. Curated set (52): `ae`, `ar`, `at`, `au`, `be`, `br`, `ca`, `ch`, `cl`, `cn`, `co`, `cz`, `de`, `dk`, `eg`, `es`, `fi`, `fr`, `gb`, `gr`, `hk`, `hu`, `id`, `ie`, `il`, `in`, `it`, `jp`, `kr`, `mx`, `my`, `ng`, `nl`, `no`, `nz`, `pe`, `ph`, `pk`, `pl`, `pt`, `ro`, `ru`, `sa`, `se`, `sg`, `th`, `tr`, `tw`, `ua`, `us`, `vn`, `za`. |
 | `fetchConfig` / `fetch_config` | object | No | Fetch options (see [Scrape · FetchConfig](/services/scrape#fetchconfig)). |
 
 <Note>


### PR DESCRIPTION
## Summary
Catches the public docs up to the API and the v1.1.0 n8n / Make app releases.

- **\`services/crawl.mdx\`** — adds \`allowExternal\` and \`contentTypes\` API parameters; documents \`maxPages\` (50), \`maxDepth\` (2), and \`maxLinksPerPage\` (10) defaults
- **\`services/search.mdx\`** — enumerates the 52 valid \`locationGeoCode\` country codes
- **\`integrations/n8n.mdx\`** — Crawl resource summary mentions MIME filters and the external-link toggle
- **\`integrations/make.mdx\`** — Crawl module field table gets Allow External Links + Content Types rows; Search Country Code is described as a curated dropdown

## Verification
- All defaults verified directly against the API zod schema (\`packages/shared/src/schemas.ts\`):
  \`\`\`ts
  maxDepth: z.coerce.number().int().min(0).default(2),
  maxPages: z.coerce.number().int().min(1).max(1000).default(50),
  maxLinksPerPage: z.coerce.number().int().min(1).default(10),
  allowExternal: z.boolean().default(false),
  \`\`\`
- 51 country codes enumerated come straight from the dashboard playground's curated list

## Test plan
- [x] \`mintlify dev\` renders without warnings
- [x] \`/services/crawl\` shows the new rows in the parameter table
- [x] \`/services/search\` shows the country code list
- [x] \`/integrations/make\` Crawl section shows the new fields
- [x] \`/integrations/n8n\` resource table mentions the new capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)