### PR TITLE
Expand dashboard settings docs (Security + Danger Zone)

### DIFF
--- a/dashboard/overview.mdx
+++ b/dashboard/overview.mdx
@@ -24,7 +24,6 @@ The ScrapeGraphAI dashboard is your central hub for managing all your web scrapi
 - **Usage Statistics**: Monitor your API usage and remaining credits
 - **Recent Jobs**: View and manage your recent scraping jobs
 - **Quick Actions**: Start new scraping jobs with just a few clicks
-- **System Status**: Check the current system status and any ongoing maintenance
 
 ## Getting Started
 

--- a/dashboard/settings.mdx
+++ b/dashboard/settings.mdx
@@ -6,40 +6,38 @@ icon: 'gear'
 
 ## Account Settings
 
-Manage your ScrapeGraphAI account settings, API keys, and preferences.
+Manage your ScrapeGraphAI account settings, billing, and security from a single place. The settings page is organized into four sections, accessible from the left-hand menu:
+
+- **Profile** — your account details
+- **Billing** — subscription, credits, and invoices
+- **Security** — password and authentication
+- **Danger Zone** — irreversible account actions
 
 <Frame>
   <img src="/images/dashboard/settings-1.png" alt="User Settings Interface" />
 </Frame>
 
-### Profile Information
+### Profile
 
-Manage your personal information and account details:
+Manage your account details:
 
-- **Basic Info**
-  - Profile picture (click to edit)
-  - First name and surname
-  - Email address
-  - Username
+- **Your Name** — the display name shown across your account. Update it and click **Save** to apply changes.
 
-### Billing Management
+### Billing
 
-Access your subscription and payment information:
+Manage your subscription and payment methods:
 
 - **Current Plan**
-  - View active subscription
-  - Usage limits and quotas
-  - Renewal date
+  - View your active plan (e.g. **Pro Plan**) and the credits remaining in your balance
+  - **Upgrade** — move to a higher plan with more features and credits
+  - **Buy Credits** — purchase additional credits on top of your current plan
 
-- **Plan History**
-  - Previous subscriptions
-  - Plan changes
-  - Usage statistics
+- **Auto Top-up**
+  - When your balance falls below a set threshold (20%), credits are automatically purchased using your saved payment card so your workloads never pause
+  - Toggle this on or off at any time
 
-- **Invoices**
-  - Download past invoices
-  - Payment history
-  - Billing address
+- **Invoice History**
+  - View and download your past payments and invoices
 
 <Note>
 Billing management options are available after purchasing a plan. Free tier users can upgrade at any time to access these features.
@@ -48,3 +46,19 @@ Billing management options are available after purchasing a plan. Free tier user
 <Card title="Upgrade Your Plan" icon="rocket" href="https://scrapegraphai.com/#pricing">
   Looking for more features? Check out our pricing plans to find the perfect fit for your needs!
 </Card>
+
+### Security
+
+Manage your password and authentication:
+
+- **Password** — change your password to keep your account secure. Click **Change Password** and we'll send a reset link to your inbox.
+
+### Danger Zone
+
+Irreversible actions for your account:
+
+- **Delete Account** — permanently delete your account and all associated data. This action cannot be undone. Your API keys, subscription, and usage history will be permanently removed.
+
+<Warning>
+Deleting your account is permanent and cannot be reversed. Make sure to download any invoices or export any data you need before proceeding.
+</Warning>

--- a/transition-from-firecrawl.mdx
+++ b/transition-from-firecrawl.mdx
@@ -654,7 +654,7 @@ const results = await Promise.all(urls.map((url) =>
 
 ### Handle the `ApiResult` wrapper
 
-The ScrapeGraph Python and JS SDKs wrap every response in an `ApiResult` — no exceptions to catch on HTTP errors. Check `status` before reading `data`:
+The ScrapeGraphAI Python and JS SDKs wrap every response in an `ApiResult` — no exceptions to catch on HTTP errors. Check `status` before reading `data`:
 
 ```python
 result = sgai.extract("...", url="https://example.com")


### PR DESCRIPTION
## Summary
Rewrites the dashboard settings page to match the current UI and adds two previously-undocumented sections.

- **Profile** — clarified the *Your Name* / Save field
- **Billing** — Current Plan, Upgrade / Buy Credits, **Auto Top-up** (auto-purchase below 20% balance), Invoice History
- **Security** — *new* — password change via emailed reset link
- **Danger Zone** — *new* — permanent account deletion (with a warning callout)

Also includes two small pre-existing working-tree edits:
- Dropped a stale "System Status" bullet from the dashboard overview
- Fixed a `ScrapeGraph` → `ScrapeGraphAI` brand name in the Firecrawl transition guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)