### PR TITLE
Document Google OAuth for the new MCP server

### DIFF
--- a/services/mcp-server/claude-code.mdx
+++ b/services/mcp-server/claude-code.mdx
@@ -9,15 +9,14 @@ icon: '/logo/claude-color.svg'
 Use the remote HTTP MCP endpoint (recommended):
 
 ```
-https://mcp.scrapegraphai.com/mcp
+https://sgai-mcp-main.onrender.com/mcp
 ```
 
 Add the server with the Claude Code CLI:
 
 ```bash
 claude mcp add --transport http sgai \
-  https://mcp.scrapegraphai.com/mcp \
-  --header "X-API-Key: YOUR_API_KEY"
+  https://sgai-mcp-main.onrender.com/mcp
 ```
 
 The default `local` scope makes the server available in the current project. To use it in every project, add `--scope user`.
@@ -28,7 +27,9 @@ Verify the connection:
 claude mcp get sgai
 ```
 
-You can also run `/mcp` inside Claude Code to view the connected tools.
+Run `/mcp` inside Claude Code, select `sgai`, and choose **Authenticate**. In the browser window, choose **Continue with Google** and sign in with the Google account associated with your ScrapeGraphAI account.
+
+After the browser shows **Authentication successful. Connected to sgai.**, return to Claude Code to view and use the connected tools.
 
 ### Local (stdio) alternative
 

--- a/services/mcp-server/claude.mdx
+++ b/services/mcp-server/claude.mdx
@@ -9,7 +9,7 @@ icon: '/logo/claude-color.svg'
 Use the remote HTTP MCP endpoint with a lightweight proxy:
 
 ```
-https://mcp.scrapegraphai.com/mcp
+https://sgai-mcp-main.onrender.com/mcp
 ```
 
 Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
@@ -21,14 +21,14 @@ Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_
       "command": "npx",
       "args": [
         "mcp-remote@0.1.25",
-        "https://mcp.scrapegraphai.com/mcp",
-        "--header",
-        "X-API-Key:YOUR_API_KEY"
+        "https://sgai-mcp-main.onrender.com/mcp"
       ]
     }
   }
 }
 ```
+
+Restart Claude Desktop after saving the configuration. The first connection opens a browser window; choose **Continue with Google** and sign in with the Google account associated with your ScrapeGraphAI account.
 
 ### Local (stdio) alternative
 
@@ -87,5 +87,3 @@ npx -y @smithery/cli install @ScrapeGraphAI/scrapegraph-mcp --client claude
 ```
 
 Prefer the Remote HTTP method above unless you specifically need Smithery provisioning.
-
-

--- a/services/mcp-server/codex.mdx
+++ b/services/mcp-server/codex.mdx
@@ -9,28 +9,25 @@ icon: '/logo/codex.svg'
 Use the remote HTTP MCP endpoint (recommended):
 
 ```
-https://mcp.scrapegraphai.com/mcp
-```
-
-Set your ScrapeGraphAI API key in the environment:
-
-```bash
-export SGAI_API_KEY=YOUR_API_KEY
+https://sgai-mcp-main.onrender.com/mcp
 ```
 
 Add the following configuration to `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.scrapegraph-mcp]
-url = "https://mcp.scrapegraphai.com/mcp"
-env_http_headers = { "X-API-Key" = "SGAI_API_KEY" }
+[mcp_servers.sgai]
+url = "https://sgai-mcp-main.onrender.com/mcp"
 ```
 
-Restart Codex after saving the configuration. Then run `/mcp` in Codex, or use the CLI, to verify the connection:
+Restart Codex after saving the configuration. Run `/mcp`, select `sgai`, and authenticate. In the browser window, choose **Continue with Google** and sign in with the Google account associated with your ScrapeGraphAI account.
+
+After the browser shows **Authentication successful. Connected to sgai.**, return to Codex and verify the connection:
 
 ```bash
-codex mcp get scrapegraph-mcp
+codex mcp get sgai
 ```
+
+To authenticate with an API key instead, set `SGAI_API_KEY` in the environment and add `bearer_token_env_var = "SGAI_API_KEY"` below the `url`.
 
 ### Local (stdio) alternative
 

--- a/services/mcp-server/cursor.mdx
+++ b/services/mcp-server/cursor.mdx
@@ -9,7 +9,7 @@ icon: '/logo/APP_ICON_2D_DARK.png'
 Use the remote HTTP MCP endpoint (recommended):
 
 ```
-https://mcp.scrapegraphai.com/mcp
+https://sgai-mcp-main.onrender.com/mcp
 ```
 
 Add this to your Cursor MCP settings (`~/.cursor/mcp.json`):
@@ -17,15 +17,18 @@ Add this to your Cursor MCP settings (`~/.cursor/mcp.json`):
 ```json
 {
   "mcpServers": {
-    "scrapegraph-mcp": {
-      "url": "https://mcp.scrapegraphai.com/mcp",
-      "headers": {
-        "X-API-Key": "YOUR_API_KEY"
-      }
+    "sgai": {
+      "url": "https://sgai-mcp-main.onrender.com/mcp"
     }
   }
 }
 ```
+
+Restart Cursor, open its MCP settings, select `sgai`, and authenticate. In the browser window, choose **Continue with Google** and sign in with the Google account associated with your ScrapeGraphAI account.
+
+Once the browser shows **Authentication successful. Connected to sgai.**, return to Cursor and start using the tools.
+
+To authenticate with an API key instead, set `SGAI_API_KEY` in Cursor's environment and add `"bearer_token_env_var": "SGAI_API_KEY"` next to the `url`.
 
 ### Local (stdio) alternative
 
@@ -84,5 +87,4 @@ npx -y @smithery/cli install @ScrapeGraphAI/scrapegraph-mcp --client claude
 ```
 
 Use this only if you specifically want Smithery provisioning. Remote HTTP (above) is the simplest path.
-
 

--- a/services/mcp-server/introduction.mdx
+++ b/services/mcp-server/introduction.mdx
@@ -67,8 +67,8 @@ The MCP server exposes the following tools via API v2:
 ## Quick Start
 
 <Steps>
-  <Step title="Get Your API Key">
-    Create an account and copy your API key from the [ScrapeGraph Dashboard](https://scrapegraphai.com/dashboard)
+  <Step title="Choose how to sign in">
+    Connect with Google in the browser, or use an API key from the [ScrapeGraph Dashboard](https://scrapegraphai.com/dashboard).
   </Step>
   <Step title="Choose Your Client">
     Select your preferred AI assistant: <a href="/services/mcp-server/cursor">Cursor</a>, <a href="/services/mcp-server/claude">Claude Desktop</a>, <a href="/services/mcp-server/claude-code">Claude Code</a>, or <a href="/services/mcp-server/codex">Codex</a>
@@ -119,10 +119,62 @@ The MCP server exposes the following tools via API v2:
 The easiest way to get started is using our hosted MCP endpoint:
 
 ```
-https://mcp.scrapegraphai.com/mcp
+https://sgai-mcp-main.onrender.com/mcp
 ```
 
-This requires no local installation and works seamlessly with Cursor, Claude Desktop, Claude Code, and Codex. See the setup guides above for configuration details.
+This requires no local installation and works with MCP-compatible clients.
+
+### Sign in with Google (recommended)
+
+Add the server without an API key:
+
+```json
+{
+  "mcpServers": {
+    "sgai": {
+      "url": "https://sgai-mcp-main.onrender.com/mcp"
+    }
+  }
+}
+```
+
+Then complete the browser authentication flow:
+
+<Steps>
+  <Step title="Restart your MCP client">
+    Restart the client after saving its MCP configuration so that it loads the new `sgai` server.
+  </Step>
+  <Step title="Start authentication">
+    Run <code>/mcp</code> in your client, select <code>sgai</code>, and choose the option to authenticate.
+  </Step>
+  <Step title="Continue with Google">
+    In the browser window that opens, select <strong>Continue with Google</strong> and use the Google account associated with your ScrapeGraphAI account.
+  </Step>
+  <Step title="Confirm the connection">
+    Return to your client after you see <strong>Authentication successful. Connected to sgai.</strong> The server is ready to use.
+  </Step>
+</Steps>
+
+### Authenticate with an API key
+
+Set your API key in the `SGAI_API_KEY` environment variable, then use this configuration:
+
+```json
+{
+  "mcpServers": {
+    "sgai": {
+      "url": "https://sgai-mcp-main.onrender.com/mcp",
+      "bearer_token_env_var": "SGAI_API_KEY"
+    }
+  }
+}
+```
+
+<Warning>
+  The previous MCP server is being deprecated. Migrate to the endpoint above and restart your client after changing the configuration.
+</Warning>
+
+See the setup guides above for client-specific configuration details.
 
 ## Local Installation
 


### PR DESCRIPTION
## Summary
- migrate the MCP docs to the new hosted endpoint
- make browser authentication with Google the recommended setup
- retain API-key authentication as an alternative
- update Cursor, Claude Desktop, Claude Code, and Codex guides

## Validation
- Mintlify preview started successfully
- rendered MCP introduction returned HTTP 200 and included the Google login instructions
- new MCP endpoint responded as expected with an authentication-required response when called without credentials
- `git diff --check` passed

## Notes
- `mintlify broken-links` reports 30 pre-existing broken links in unrelated files; this change adds none