### PR TITLE
Update MCP docs to custom hosted endpoint

### DIFF
--- a/services/mcp-server/claude-code.mdx
+++ b/services/mcp-server/claude-code.mdx
@@ -9,14 +9,14 @@ icon: '/logo/claude-color.svg'
 Use the remote HTTP MCP endpoint (recommended):
 
 ```
-https://sgai-mcp-main.onrender.com/mcp
+https://mcp.scrapegraphai.com/mcp
 ```
 
 Add the server with the Claude Code CLI:
 
 ```bash
 claude mcp add --transport http sgai \
-  https://sgai-mcp-main.onrender.com/mcp
+  https://mcp.scrapegraphai.com/mcp
 ```
 
 The default `local` scope makes the server available in the current project. To use it in every project, add `--scope user`.

--- a/services/mcp-server/claude.mdx
+++ b/services/mcp-server/claude.mdx
@@ -9,7 +9,7 @@ icon: '/logo/claude-color.svg'
 Use the remote HTTP MCP endpoint with a lightweight proxy:
 
 ```
-https://sgai-mcp-main.onrender.com/mcp
+https://mcp.scrapegraphai.com/mcp
 ```
 
 Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
@@ -21,7 +21,7 @@ Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_
       "command": "npx",
       "args": [
         "mcp-remote@0.1.25",
-        "https://sgai-mcp-main.onrender.com/mcp"
+        "https://mcp.scrapegraphai.com/mcp"
       ]
     }
   }

--- a/services/mcp-server/codex.mdx
+++ b/services/mcp-server/codex.mdx
@@ -9,14 +9,14 @@ icon: '/logo/codex.svg'
 Use the remote HTTP MCP endpoint (recommended):
 
 ```
-https://sgai-mcp-main.onrender.com/mcp
+https://mcp.scrapegraphai.com/mcp
 ```
 
 Add the following configuration to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.sgai]
-url = "https://sgai-mcp-main.onrender.com/mcp"
+url = "https://mcp.scrapegraphai.com/mcp"
 ```
 
 Restart Codex after saving the configuration. Run `/mcp`, select `sgai`, and authenticate. In the browser window, choose **Continue with Google** and sign in with the Google account associated with your ScrapeGraphAI account.

--- a/services/mcp-server/cursor.mdx
+++ b/services/mcp-server/cursor.mdx
@@ -9,7 +9,7 @@ icon: '/logo/APP_ICON_2D_DARK.png'
 Use the remote HTTP MCP endpoint (recommended):
 
 ```
-https://sgai-mcp-main.onrender.com/mcp
+https://mcp.scrapegraphai.com/mcp
 ```
 
 Add this to your Cursor MCP settings (`~/.cursor/mcp.json`):
@@ -18,7 +18,7 @@ Add this to your Cursor MCP settings (`~/.cursor/mcp.json`):
 {
   "mcpServers": {
     "sgai": {
-      "url": "https://sgai-mcp-main.onrender.com/mcp"
+      "url": "https://mcp.scrapegraphai.com/mcp"
     }
   }
 }
@@ -87,4 +87,3 @@ npx -y @smithery/cli install @ScrapeGraphAI/scrapegraph-mcp --client claude
 ```
 
 Use this only if you specifically want Smithery provisioning. Remote HTTP (above) is the simplest path.
-

--- a/services/mcp-server/introduction.mdx
+++ b/services/mcp-server/introduction.mdx
@@ -22,7 +22,7 @@ The Model Context Protocol (MCP) is a standardized way for AI assistants to acce
 ## Key Features
 
 <CardGroup cols={2}>
-  <Card title="17 Powerful Tools" icon="tools">
+  <Card title="20 Powerful Tools" icon="tools">
     Scrape, extract, search, crawl, generate schemas, monitor scheduled jobs (with activity polling), and manage your account
   </Card>
   <Card title="Remote & Local" icon="server">
@@ -46,22 +46,25 @@ The MCP server exposes the following tools via API v2:
 | **extract** | AI-powered structured extraction from a URL (POST /extract) |
 | **search** | Search the web and extract structured results (POST /search) |
 | **crawl_start** | Start async multi-page crawl — markdown, html, links, images, summary, branding, or screenshot (POST /crawl) |
-| **crawl_get_status** | Poll crawl results (GET /crawl/:id) |
+| **crawl_get** | Get crawl status and pages (GET /crawl/:id) |
+| **crawl_pages** | Get paginated crawl pages (GET /crawl/:id/pages) |
 | **crawl_stop** | Stop a running crawl job (POST /crawl/:id/stop) |
 | **crawl_resume** | Resume a stopped crawl job (POST /crawl/:id/resume) |
-| **schema** | Generate or augment a JSON Schema from a prompt (POST /schema) |
+| **crawl_delete** | Delete a crawl job (DELETE /crawl/:id) |
 | **credits** | Check your credit balance (GET /credits) |
-| **history** | Browse request history with pagination (GET /history) |
+| **history_list** | Browse request history with pagination (GET /history) |
+| **history_get** | Get a request history entry (GET /history/:id) |
 | **monitor_create** | Create a scheduled extraction job (POST /monitor) |
 | **monitor_list** | List all monitors (GET /monitor) |
 | **monitor_get** | Get monitor details (GET /monitor/:id) |
+| **monitor_update** | Update a monitor (PATCH /monitor/:id) |
 | **monitor_pause** | Pause a running monitor (POST /monitor/:id/pause) |
 | **monitor_resume** | Resume a paused monitor (POST /monitor/:id/resume) |
 | **monitor_delete** | Delete a monitor (DELETE /monitor/:id) |
 | **monitor_activity** | Poll tick history for a monitor with pagination (GET /monitor/:id/activity) |
 
 <Note>
-  **Migrating from v2 (scrapegraph-mcp ≤ 2.x)?** Tools were renamed in v3.0.0 to match the v2 API canonical names: `smartscraper` → `extract`, `searchscraper` → `search`, `smartcrawler_initiate` → `crawl_start`, `smartcrawler_fetch_results` → `crawl_get_status`, `sgai_history` → `history`, `generate_schema` → `schema`. `markdownify` was removed — use `scrape` with `output_format="markdown"` instead. See the [v3.0.0 release notes](https://github.com/ScrapeGraphAI/scrapegraph-mcp/releases/tag/v3.0.0) for full details.
+  **Migrating from v2 (scrapegraph-mcp ≤ 2.x)?** Tools were renamed in v3.0.0 to match the v2 API canonical names: `smartscraper` → `extract`, `searchscraper` → `search`, `smartcrawler_initiate` → `crawl_start`, `smartcrawler_fetch_results` → `crawl_get`, `sgai_history` → `history_list`. `markdownify` was removed — use `scrape` with `output_format="markdown"` instead. See the [v3.0.0 release notes](https://github.com/ScrapeGraphAI/scrapegraph-mcp/releases/tag/v3.0.0) for full details.
 </Note>
 
 ## Quick Start

--- a/services/mcp-server/introduction.mdx
+++ b/services/mcp-server/introduction.mdx
@@ -119,7 +119,7 @@ The MCP server exposes the following tools via API v2:
 The easiest way to get started is using our hosted MCP endpoint:
 
 ```
-https://sgai-mcp-main.onrender.com/mcp
+https://mcp.scrapegraphai.com/mcp
 ```
 
 This requires no local installation and works with MCP-compatible clients.
@@ -132,7 +132,7 @@ Add the server without an API key:
 {
   "mcpServers": {
     "sgai": {
-      "url": "https://sgai-mcp-main.onrender.com/mcp"
+      "url": "https://mcp.scrapegraphai.com/mcp"
     }
   }
 }
@@ -163,7 +163,7 @@ Set your API key in the `SGAI_API_KEY` environment variable, then use this confi
 {
   "mcpServers": {
     "sgai": {
-      "url": "https://sgai-mcp-main.onrender.com/mcp",
+      "url": "https://mcp.scrapegraphai.com/mcp",
       "bearer_token_env_var": "SGAI_API_KEY"
     }
   }


### PR DESCRIPTION
## Summary
- replace the Render MCP URL with the custom ScrapeGraphAI domain
- update Cursor, Claude Desktop, Claude Code, and Codex examples

## Verification
- authenticated MCP initialize request returned HTTP 200
- server identified as scrapegraphai-mcp v2.0.0
- git diff --check passed
- Mintlify link check introduced no new broken links